### PR TITLE
gitlab-19: Use yalc to support local development on gpl lib and surf app at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,10 @@ Thumbs.db
 
 # Next.js
 .next
+
+# VsCode
+.vscode
+
+# Yalc
+/.yalc
+yalc.lock

--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,6 @@ node_modules
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 # misc
 /.sass-cache
@@ -41,9 +37,6 @@ Thumbs.db
 
 # Next.js
 .next
-
-# VsCode
-.vscode
 
 # Yalc
 /.yalc

--- a/README.md
+++ b/README.md
@@ -25,29 +25,6 @@ Run `npx nx connect-to-nx-cloud` to enable [remote caching](https://nx.app) and 
 
 Visit the [Nx Documentation](https://nx.dev) to learn more.
 
-## Link locally to the orchestrator-ui-components npm library
-
-When working on the orchestrator-ui-components library combined with an implementation of the orchestrator-ui app, a local link can be used by running `./link-start.sh`. This will expose the library for local development. To connect to the local version of the npm package, run the folowing commands in the custom orchestrator-ui app:
-
-```shell
-rm -rf node_modules/.cache
-yarn link @orchestrator-ui/orchestrator-ui-components
-yarn link react
-yarn link react-dom
-```
-
-To stop using the link, first run the following commands in the custom version of the orchestrator-ui app:
-
-```shell
-yarn unlink @orchestrator-ui/orchestrator-ui-components
-yarn unlink react
-yarn unlink react-dom
-rm -rf node_modules/.cache
-yarn install --force
-```
-
-Finally run `./link-stop.sh` to stop exposing the orchestrator-ui-components library package
-
 # Types
 
 ## Generic rules
@@ -57,15 +34,38 @@ Finally run `./link-stop.sh` to stop exposing the orchestrator-ui-components lib
 -   We assume that most users will only want to add columns/fields in Subscriptions, Subscription, Processes, Process
 -   We assume that certain fields are not changeable, for example fields that are used by workflow engine related objects;
     like workflow status, subscription status.
--   Naming, no real naming convention yet, but for starters: `SubscriptionDetailBase` and `SubscriptionTableBase` for
-    stuff in lib
+-   Naming, no real naming convention yet, but for starters: `SubscriptionDetailBase` and `SubscriptionTableBase` for stuff in lib
 
 ## Actions:
 
 -   When orchestrator subscription graphql reference endpoint is ready -> move the `__generated__` folder to lib (or to a
     separate types package); so the lib will contain the reference graphql types for a specific version of
-    orchestrator-core: upon build we can check this and let the build fail when the type mappers can not be used without
-    warning, because backwards incompatible changes were done in the backend
+    orchestrator-core: upon build we can check this and let the build fail when the type mappers can not be used without warning, because backwards incompatible changes were done in the backend
 -   There are fields in the core like: `Process.Assignee` and `Subscription.CustomerAbbrevation` they should be
     removed/changed for enum values like `KLANTSUPPORT`. Probably around 4 a 5 SURF specific fields, Note: when the remove
     is done, this is the first actual use case for type customisation that we can test.
+
+## Publishing @orchestrator-ui/orchestrator-ui-components to NPM
+
+The contents of /src/lib are published as a library on npm: [@orchestrator-ui/orchestrator-ui-components][1]
+
+In order to publish a new version to NPM:
+
+1. Manually update the version number in /libs/orchestration-ui-components/package.json
+1. Create a new build, this will create a dist folder at [root]/dist
+   `yarn build:orchestrator-ui-components`
+1. Deploy the version
+   `yarn publish dist/libs/orchestrator-ui-components`
+   TODO: Add login steps
+
+## Link locally to the orchestrator-ui-components npm library using Yalc
+
+When working on the orchestrator-ui-components library from another repository, a local link can be used to see updates to the local changes directly in the consuming app by running `./link-start.sh`.
+
+Additionally in the consuming application run
+
+`npx yalc link @orchestrator-ui/orchestrator-ui-components`
+
+After stopping yalc you can optionally remove the yalc store at this location "npx yalc dir"
+
+[1]:[https://www.npmjs.com/package/@orchestrator-ui/orchestrator-ui-components]

--- a/link-start.sh
+++ b/link-start.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-yarn run build:orchestrator-ui-components
-cd dist/libs/orchestrator-ui-components || exit
-yarn link
-cd ../../../node_modules/react || exit
-yarn link
-cd ../react-dom || exit
-yarn link
-cd ../../
-yarn run build-watch:orchestrator-ui-components
+npx nx build orchestrator-ui-components && npx yalc publish --push dist/libs/orchestrator-ui-components
+npx nx watch --projects=orchestrator-ui-components -- 'npx nx build orchestrator-ui-components && npx yalc publish --push dist/libs/orchestrator-ui-components'
+## After stopping yalc you can optionally remove the yalc store at this location "npx yalc dir"

--- a/link-stop.sh
+++ b/link-stop.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd dist/libs/orchestrator-ui-components || exit
-yarn unlink
-cd ../../../node_modules/react || exit
-yarn unlink
-cd ../react-dom || exit
-yarn unlink

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "storybook-addon-mock": "^4.0.0",
         "ts-jest": "28.0.5",
         "ts-node": "10.9.1",
-        "typescript": "~4.8.2"
+        "typescript": "~4.8.2",
+        "yalc": "^1.0.0-pre.53"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9215,7 +9215,7 @@ fs-extra@^10.0.0, fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^8.1.0:
+fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -10210,6 +10210,13 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==
 
+ignore-walk@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
+  integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
+  dependencies:
+    minimatch "^3.0.4"
+
 ignore@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -10315,7 +10322,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
-ini@2.0.0:
+ini@2.0.0, ini@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
@@ -12791,6 +12798,28 @@ normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
+npm-bundled@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
+  integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
+npm-packlist@^2.1.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-2.2.2.tgz#076b97293fa620f632833186a7a8f65aaa6148c8"
+  integrity sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==
+  dependencies:
+    glob "^7.1.6"
+    ignore-walk "^3.0.3"
+    npm-bundled "^1.1.1"
+    npm-normalize-package-bin "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -17727,6 +17756,20 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yalc@^1.0.0-pre.53:
+  version "1.0.0-pre.53"
+  resolved "https://registry.yarnpkg.com/yalc/-/yalc-1.0.0-pre.53.tgz#c51db2bb924a6908f4cb7e82af78f7e5606810bc"
+  integrity sha512-tpNqBCpTXplnduzw5XC+FF8zNJ9L/UXmvQyyQj7NKrDNavbJtHvzmZplL5ES/RCnjX7JR7W9wz5GVDXVP3dHUQ==
+  dependencies:
+    chalk "^4.1.0"
+    detect-indent "^6.0.0"
+    fs-extra "^8.0.1"
+    glob "^7.1.4"
+    ignore "^5.0.4"
+    ini "^2.0.0"
+    npm-packlist "^2.1.5"
+    yargs "^16.1.1"
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -17782,7 +17825,7 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.2.0:
+yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
## Summary
Setup to use Yalc as a tool to be able to work on the GPL component library and the Surf app implemation locally at the same time

## DOD Tasks
X Add/Update documentation.