### PR TITLE
110 updates eslint package

### DIFF
--- a/.changeset/wild-walls-destroy.md
+++ b/.changeset/wild-walls-destroy.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/eslint-config-custom': patch
+---
+
+Adds eslint dependency

--- a/apps/wfo-ui/next.config.js
+++ b/apps/wfo-ui/next.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     reactStrictMode: false,
+    transpilePackages: ['@orchestrator-ui/orchestrator-ui-components'],
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@turbo/gen": "^1.9.7",
-        "eslint": "^8.45.0",
         "eslint-config-custom": "*",
         "husky": "^8.0.0",
         "prettier": "^2.5.1",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -9,6 +9,7 @@
     },
     "dependencies": {
         "@typescript-eslint/eslint-plugin": "5.61.0",
+        "eslint": "^8.45.0",
         "eslint-config-next": "^13.4.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "7.28.0",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -7,7 +7,7 @@
         "build": "tsup index.js --format esm",
         "dev": "yarn build -- --watch"
     },
-    "dependencies": {
+    "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.61.0",
         "eslint": "^8.45.0",
         "eslint-config-next": "^13.4.1",


### PR DESCRIPTION
The changes made in this PR should make it possible to just copy the app and run it standalone.
- Eslint was missing in the eslint package, moved it from the root-package.json to the config package
- Running stanalone requires the transpile prop to be populated in the nextjs config