### PR TITLE
86 metadata productblocks page

### DIFF
--- a/apps/wfo-ui/components/Metadata/Products/Products.tsx
+++ b/apps/wfo-ui/components/Metadata/Products/Products.tsx
@@ -9,7 +9,6 @@ import {
     WFOProductBlockBadge,
     useQueryWithGraphql,
     getTypedFieldFromObject,
-    parseDateToLocaleString,
 } from '@orchestrator-ui/orchestrator-ui-components';
 
 import type {
@@ -30,7 +29,6 @@ import { useTranslations } from 'next-intl';
 import { GET_PRODUCTS_GRAPHQL_QUERY } from './productsQuery';
 
 import { METADATA_PRODUCT_TABLE_LOCAL_STORAGE_KEY } from '../../../constants';
-import { MetadataProductsQuery } from '../../../__generated__/graphql';
 import { useRouter } from 'next/router';
 import { mapToGraphQlSortBy } from '../../../utils/queryVarsMappers';
 
@@ -181,16 +179,3 @@ export const Products: FC<ProductsProps> = ({
         />
     );
 };
-/*
-function mapApiResponseToProductTableData(
-    graphqlResponse: MetadataProductsQuery,
-): ProductDefinition[] {
-    return graphqlResponse.products.page.map(
-        (product): ProductDefinition => ({
-            ...product,
-            createdAt: product.createdAt,
-            productId: 'TEMPID'
-        }),
-    );
-}
-*/

--- a/apps/wfo-ui/components/Metadata/Products/Products.tsx
+++ b/apps/wfo-ui/components/Metadata/Products/Products.tsx
@@ -9,13 +9,12 @@ import {
     WFOProductBlockBadge,
     useQueryWithGraphql,
     getTypedFieldFromObject,
-    parseDate,
     parseDateToLocaleString,
 } from '@orchestrator-ui/orchestrator-ui-components';
 
 import type {
     DataDisplayParams,
-    Product,
+    ProductDefinition,
 } from '@orchestrator-ui/orchestrator-ui-components';
 
 import {
@@ -35,21 +34,26 @@ import { MetadataProductsQuery } from '../../../__generated__/graphql';
 import { useRouter } from 'next/router';
 import { mapToGraphQlSortBy } from '../../../utils/queryVarsMappers';
 
-export const PRODUCT_FIELD_NAME: keyof Product = 'name';
-export const PRODUCT_FIELD_DESCRIPTION: keyof Product = 'description';
-export const PRODUCT_FIELD_TAG: keyof Product = 'tag';
-export const PRODUCT_FIELD_PRODUCT_TYPE: keyof Product = 'productType';
-export const PRODUCT_FIELD_STATUS: keyof Product = 'status';
-export const PRODUCT_FIELD_PRODUCT_BLOCKS: keyof Product = 'productBlocks';
-export const PRODUCT_FIELD_CREATED_AT: keyof Product = 'createdAt';
+export const PRODUCT_FIELD_PRODUCT_ID: keyof ProductDefinition = 'productId';
+export const PRODUCT_FIELD_NAME: keyof ProductDefinition = 'name';
+export const PRODUCT_FIELD_DESCRIPTION: keyof ProductDefinition = 'description';
+export const PRODUCT_FIELD_TAG: keyof ProductDefinition = 'tag';
+export const PRODUCT_FIELD_PRODUCT_TYPE: keyof ProductDefinition =
+    'productType';
+export const PRODUCT_FIELD_STATUS: keyof ProductDefinition = 'status';
+export const PRODUCT_FIELD_PRODUCT_BLOCKS: keyof ProductDefinition =
+    'productBlocks';
+export const PRODUCT_FIELD_FIXED_INPUTS: keyof ProductDefinition =
+    'fixedInputs';
+export const PRODUCT_FIELD_CREATED_AT: keyof ProductDefinition = 'createdAt';
 
 export type ProductsProps = {
-    dataDisplayParams: DataDisplayParams<Product>;
+    dataDisplayParams: DataDisplayParams<ProductDefinition>;
     setDataDisplayParam: <
-        DisplayParamKey extends keyof DataDisplayParams<Product>,
+        DisplayParamKey extends keyof DataDisplayParams<ProductDefinition>,
     >(
         prop: DisplayParamKey,
-        value: DataDisplayParams<Product>[DisplayParamKey],
+        value: DataDisplayParams<ProductDefinition>[DisplayParamKey],
     ) => void;
 };
 
@@ -59,7 +63,12 @@ export const Products: FC<ProductsProps> = ({
 }) => {
     const router = useRouter();
     const t = useTranslations('metadata.product');
-    const tableColumns: TableColumns<Product> = {
+    const tableColumns: TableColumns<ProductDefinition> = {
+        productId: {
+            field: PRODUCT_FIELD_PRODUCT_ID,
+            name: t('id'),
+            width: '110',
+        },
         name: {
             field: PRODUCT_FIELD_NAME,
             name: t('name'),
@@ -99,20 +108,33 @@ export const Products: FC<ProductsProps> = ({
                 </>
             ),
         },
+        fixedInputs: {
+            field: PRODUCT_FIELD_FIXED_INPUTS,
+            name: t('fixedInputs'),
+            render: (fixedInputs) => (
+                <>
+                    {fixedInputs.map((fixedInput, index) => (
+                        <WFOProductBlockBadge key={index}>
+                            {`${fixedInput.name}: ${fixedInput.value}`}
+                        </WFOProductBlockBadge>
+                    ))}
+                </>
+            ),
+        },
         createdAt: {
             field: PRODUCT_FIELD_CREATED_AT,
             name: t('createdAt'),
-            render: parseDateToLocaleString,
         },
     };
 
-    const sortBy = mapToGraphQlSortBy(dataDisplayParams.sortBy);
+    const sortBy = mapToGraphQlSortBy<ProductDefinition>(
+        dataDisplayParams.sortBy,
+    );
     const { data, isFetching } = useQueryWithGraphql(
         GET_PRODUCTS_GRAPHQL_QUERY,
         {
             first: dataDisplayParams.pageSize,
             after: dataDisplayParams.pageIndex * dataDisplayParams.pageSize,
-            sortBy,
         },
         'products',
         true,
@@ -129,25 +151,27 @@ export const Products: FC<ProductsProps> = ({
         pageSize: dataDisplayParams.pageSize,
         pageIndex: dataDisplayParams.pageIndex,
         pageSizeOptions: DEFAULT_PAGE_SIZES,
-        totalItemCount: totalItems ? parseInt(totalItems) : 0,
+        totalItemCount: totalItems ? totalItems : 0,
     };
 
-    const dataSorting: DataSorting<Product> = {
+    const dataSorting: DataSorting<ProductDefinition> = {
         field: dataDisplayParams.sortBy?.field ?? PRODUCT_FIELD_NAME,
         sortOrder: dataDisplayParams.sortBy?.order ?? SortOrder.ASC,
     };
 
     return (
-        <TableWithFilter<Product>
-            data={data ? mapApiResponseToProductTableData(data) : []}
+        <TableWithFilter<ProductDefinition>
+            data={data ? data.products.page : []}
             tableColumns={tableColumns}
             dataSorting={dataSorting}
-            onUpdateDataSort={getDataSortHandler<Product>(
+            onUpdateDataSort={getDataSortHandler<ProductDefinition>(
                 dataDisplayParams,
                 setDataDisplayParam,
             )}
-            onUpdatePage={getPageChangeHandler<Product>(setDataDisplayParam)}
-            onUpdateEsQueryString={getEsQueryStringHandler<Product>(
+            onUpdatePage={getPageChangeHandler<ProductDefinition>(
+                setDataDisplayParam,
+            )}
+            onUpdateEsQueryString={getEsQueryStringHandler<ProductDefinition>(
                 setDataDisplayParam,
             )}
             pagination={pagination}
@@ -157,14 +181,16 @@ export const Products: FC<ProductsProps> = ({
         />
     );
 };
-
+/*
 function mapApiResponseToProductTableData(
     graphqlResponse: MetadataProductsQuery,
-): Product[] {
+): ProductDefinition[] {
     return graphqlResponse.products.page.map(
-        (product): Product => ({
+        (product): ProductDefinition => ({
             ...product,
-            createdAt: parseDate(product.createdAt),
+            createdAt: product.createdAt,
+            productId: 'TEMPID'
         }),
     );
 }
+*/

--- a/apps/wfo-ui/components/Metadata/Products/productsQuery.ts
+++ b/apps/wfo-ui/components/Metadata/Products/productsQuery.ts
@@ -1,18 +1,29 @@
-import { SortOrder } from '@orchestrator-ui/orchestrator-ui-components';
-import type { Product } from '@orchestrator-ui/orchestrator-ui-components';
-import { graphql } from '../../../__generated__';
+import { gql } from 'graphql-request';
+import { parse } from 'graphql';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-export const DEFAULT_SORT_FIELD: keyof Product = 'name';
+import { SortOrder } from '@orchestrator-ui/orchestrator-ui-components';
+import type {
+    ProductDefinition,
+    GraphqlQueryVariables,
+    ProductDefinitionsResult,
+} from '@orchestrator-ui/orchestrator-ui-components';
+
+export const DEFAULT_SORT_FIELD: keyof ProductDefinition = 'name';
 export const DEFAULT_SORT_ORDER: SortOrder = SortOrder.DESC;
 
-export const GET_PRODUCTS_GRAPHQL_QUERY = graphql(`
+export const GET_PRODUCTS_GRAPHQL_QUERY: TypedDocumentNode<
+    ProductDefinitionsResult,
+    GraphqlQueryVariables<ProductDefinition>
+> = parse(gql`
     query MetadataProducts(
-        $first: Int!
-        $after: Int!
+        $first: IntType!
+        $after: IntType!
         $sortBy: [GraphqlSort!]
     ) {
         products(first: $first, after: $after, sortBy: $sortBy) {
             page {
+                productId
                 name
                 description
                 tag
@@ -22,6 +33,11 @@ export const GET_PRODUCTS_GRAPHQL_QUERY = graphql(`
                 productBlocks {
                     name
                 }
+                fixedInputs {
+                    name
+                    value
+                }
+                endDate
             }
             pageInfo {
                 endCursor

--- a/apps/wfo-ui/pages/metadata/productblocks.tsx
+++ b/apps/wfo-ui/pages/metadata/productblocks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ProductBlocksPage as Page } from '@orchestrator-ui/orchestrator-ui-components';
+import { WFOProductBlocksPage as Page } from '@orchestrator-ui/orchestrator-ui-components';
 
 export const ProductBlocksPage = () => <Page />;
 

--- a/apps/wfo-ui/pages/metadata/productblocks.tsx
+++ b/apps/wfo-ui/pages/metadata/productblocks.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { ProductBlocksPage as Page } from '@orchestrator-ui/orchestrator-ui-components';
 
-export const ProductBlocksPage = () => (
-    <Page />
-);
+export const ProductBlocksPage = () => <Page />;
 
 export default ProductBlocksPage;

--- a/apps/wfo-ui/pages/metadata/productblocks.tsx
+++ b/apps/wfo-ui/pages/metadata/productblocks.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
-import { MetaDataLayout } from '../../components/Metadata/PageLayout/layout';
-
-const ProductBlocksPageContent = () => <div>METADATA PRODUCT BLOCKS</div>;
+import { ProductBlocksPage as Page } from '@orchestrator-ui/orchestrator-ui-components';
 
 export const ProductBlocksPage = () => (
-    <MetaDataLayout>
-        <ProductBlocksPageContent />
-    </MetaDataLayout>
+    <Page />
 );
 
 export default ProductBlocksPage;

--- a/apps/wfo-ui/pages/metadata/products.tsx
+++ b/apps/wfo-ui/pages/metadata/products.tsx
@@ -11,7 +11,7 @@ import {
     getTableConfigFromLocalStorage,
     useDataDisplayParams,
 } from '@orchestrator-ui/orchestrator-ui-components';
-import type { Product } from '@orchestrator-ui/orchestrator-ui-components';
+import type { ProductDefinition } from '@orchestrator-ui/orchestrator-ui-components';
 
 import { SortOrder } from '@orchestrator-ui/orchestrator-ui-components';
 import { useRouter } from 'next/router';
@@ -24,7 +24,7 @@ const ProductsPageContent = () => {
         getTableConfigFromLocalStorage(METADATA_PRODUCT_TABLE_LOCAL_STORAGE_KEY)
             ?.selectedPageSize ?? DEFAULT_PAGE_SIZE;
     const { dataDisplayParams, setDataDisplayParam } =
-        useDataDisplayParams<Product>({
+        useDataDisplayParams<ProductDefinition>({
             pageSize: initialPageSize,
             sortBy: {
                 field: PRODUCT_FIELD_NAME,

--- a/apps/wfo-ui/utils/queryVarsMappers.ts
+++ b/apps/wfo-ui/utils/queryVarsMappers.ts
@@ -14,9 +14,9 @@ export const mapSortOrderToGraphQlSortOrder = (
 
 export const mapToGraphQlSortBy = <Type>(
     sortBy: GraphQLSort<Type> | undefined,
-): GraphqlSort | null => {
+): GraphqlSort | undefined => {
     if (!sortBy?.order || !sortBy?.field) {
-        return null;
+        return undefined;
     }
 
     const { field, order } = sortBy;

--- a/apps/wfo-ui/utils/queryVarsMappers.ts
+++ b/apps/wfo-ui/utils/queryVarsMappers.ts
@@ -13,12 +13,8 @@ export const mapSortOrderToGraphQlSortOrder = (
     value === SortOrder.ASC ? SortOrderGraphql.Asc : SortOrderGraphql.Desc;
 
 export const mapToGraphQlSortBy = <Type>(
-    sortBy: GraphQLSort<Type> | undefined,
-): GraphqlSort | undefined => {
-    if (!sortBy?.order || !sortBy?.field) {
-        return undefined;
-    }
-
+    sortBy: GraphQLSort<Type>,
+): GraphqlSort => {
     const { field, order } = sortBy;
     return {
         field: field.toString(),

--- a/packages/orchestrator-ui-components/src/components/Table/utils/constants.ts
+++ b/packages/orchestrator-ui-components/src/components/Table/utils/constants.ts
@@ -1,2 +1,5 @@
 export const DEFAULT_PAGE_SIZES = [5, 10, 15, 20, 25, 100];
 export const DEFAULT_PAGE_SIZE = 10;
+
+export const METADATA_PRODUCTBLOCKS_TABLE_LOCAL_STORAGE_KEY =
+    'metadataProductBlocksTable';

--- a/packages/orchestrator-ui-components/src/graphqlQueries/index.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/index.ts
@@ -1,0 +1,1 @@
+export * from './productBlocksQuery';

--- a/packages/orchestrator-ui-components/src/graphqlQueries/productBlocksQuery.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/productBlocksQuery.ts
@@ -5,30 +5,33 @@ import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { SortOrder } from '../types';
 
 import type { ProductBlockDefinition } from '../types';
-import { GraphqlQueryVariables, GraphQLResult } from '../types';
+import { GraphqlQueryVariables, ProductBlockDefinitionsResult } from '../types';
 
 export const DEFAULT_SORT_FIELD: keyof ProductBlockDefinition = 'name';
 export const DEFAULT_SORT_ORDER: SortOrder = SortOrder.DESC;
 
 export const GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY: TypedDocumentNode<
-    GraphQLResult<ProductBlockDefinition>,
+    ProductBlockDefinitionsResult,
     GraphqlQueryVariables<ProductBlockDefinition>
 > = parse(gql`
     query MetadataProductBlocks(
-        $first: Int!
-        $after: Int!
+        $first: IntType!
+        $after: IntType!
         $sortBy: [GraphqlSort!]
     ) {
-        results(first: $first, after: $after, sortBy: $sortBy) {
+        productBlocks(first: $first, after: $after, sortBy: $sortBy) {
             page {
+                productBlockId
                 name
-                description
                 tag
-                createdAt
-                productType
+                description
                 status
-                productBlocks {
-                    name
+                createdAt
+                endDate
+                resourceTypes {
+                    description
+                    resourceType
+                    resourceTypeId
                 }
             }
             pageInfo {

--- a/packages/orchestrator-ui-components/src/graphqlQueries/productBlocksQuery.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/productBlocksQuery.ts
@@ -1,0 +1,43 @@
+import { gql } from 'graphql-request';
+import { parse } from 'graphql';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { SortOrder } from '../types';
+
+import type { ProductBlockDefinition } from '../types';
+import { GraphqlQueryVariables, GraphQLResult } from '../types';
+
+export const DEFAULT_SORT_FIELD: keyof ProductBlockDefinition = 'name';
+export const DEFAULT_SORT_ORDER: SortOrder = SortOrder.DESC;
+
+export const GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY: TypedDocumentNode<
+    GraphQLResult<ProductBlockDefinition>,
+    GraphqlQueryVariables<ProductBlockDefinition>
+> = parse(gql`
+    query MetadataProductBlocks(
+        $first: Int!
+        $after: Int!
+        $sortBy: [GraphqlSort!]
+    ) {
+        results(first: $first, after: $after, sortBy: $sortBy) {
+            page {
+                name
+                description
+                tag
+                createdAt
+                productType
+                status
+                productBlocks {
+                    name
+                }
+            }
+            pageInfo {
+                endCursor
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                totalItems
+            }
+        }
+    }
+`);

--- a/packages/orchestrator-ui-components/src/hooks/useDataDisplayParams.ts
+++ b/packages/orchestrator-ui-components/src/hooks/useDataDisplayParams.ts
@@ -12,7 +12,7 @@ import { DEFAULT_PAGE_SIZE } from '../components';
 export type DataDisplayParams<Type> = {
     pageSize: number;
     pageIndex: number;
-    sortBy?: GraphQLSort<Type>;
+    sortBy: GraphQLSort<Type>;
     esQueryString?: string; // The filter param is going to send to the backend as is for parsing
 };
 

--- a/packages/orchestrator-ui-components/src/index.ts
+++ b/packages/orchestrator-ui-components/src/index.ts
@@ -6,3 +6,4 @@ export * from './contexts';
 export * from './types';
 export * from './hooks';
 export * from './messages';
+export * from './pages';

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -21,9 +21,19 @@
             "description": "Description",
             "tag": "Tag",
             "productType": "Type",
-            "status": "status",
+            "status": "Status",
             "productBlocks": "Product blocks",
             "createdAt": "Created"
+        },
+        "productBlocks": {
+            "name": "Name",
+            "description": "Description",
+            "tag": "Tag",
+            "status": "status",
+            "resourceTypes": "Resource types",
+            "createdAt": "Created",
+            "endDate": "End date",
+            "parentIds": "Parents"
         }
     },
     "subscriptions": {

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -26,6 +26,7 @@
             "createdAt": "Created"
         },
         "productBlocks": {
+            "id": "ID",
             "name": "Name",
             "description": "Description",
             "tag": "Tag",

--- a/packages/orchestrator-ui-components/src/pages/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './metadata'

--- a/packages/orchestrator-ui-components/src/pages/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/index.ts
@@ -1,1 +1,1 @@
-export * from './metadata'
+export * from './metadata';

--- a/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export const ProductBlocksPage = () => {
-    return <div>ProductBLOCKSpaGE!!!!</div>;
-};

--- a/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const ProductBlocksPage = () => {
+  return (
+    <div>ProductBLOCKSpaGE!!!!</div>
+  )
+}

--- a/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/ProductBlocksPage.tsx
@@ -1,7 +1,5 @@
-import React from 'react'
+import React from 'react';
 
 export const ProductBlocksPage = () => {
-  return (
-    <div>ProductBLOCKSpaGE!!!!</div>
-  )
-}
+    return <div>ProductBLOCKSpaGE!!!!</div>;
+};

--- a/packages/orchestrator-ui-components/src/pages/metadata/WFOMetadataPageLayout.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WFOMetadataPageLayout.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { EuiSpacer, EuiPageHeader, EuiTab, EuiTabs } from '@elastic/eui';
+import { useRouter } from 'next/router';
+import { useTranslations } from 'next-intl';
+
+interface MetadataLayoutProps {
+    children: ReactNode;
+    tabs?: MetaDataTab[];
+}
+
+export interface MetaDataTab {
+    id: number;
+    translationKey: string;
+    path: string;
+}
+
+const metaDataTabs: MetaDataTab[] = [
+    {
+        id: 1,
+        translationKey: 'products',
+        path: '/metadata/products',
+    },
+    {
+        id: 2,
+        translationKey: 'productBlocks',
+        path: '/metadata/productblocks',
+    },
+    {
+        id: 3,
+        translationKey: 'resourceTypes',
+        path: '/metadata/resource-types',
+    },
+    {
+        id: 4,
+        translationKey: 'fixedInputs',
+        path: '/metadata/fixed-inputs',
+    },
+    {
+        id: 5,
+        translationKey: 'workflows',
+        path: '/metadata/workflows',
+    },
+];
+
+export const WFOMetadataPageLayout = ({
+    children,
+    tabs = metaDataTabs,
+}: MetadataLayoutProps) => {
+    const router = useRouter();
+    const t = useTranslations('metadata.tabs');
+    const currentPath = router.pathname;
+
+    return (
+        <>
+            <EuiSpacer />
+
+            <EuiPageHeader pageTitle="Metadata" />
+            <EuiSpacer size="m" />
+            <EuiTabs>
+                {tabs.map(({ id, translationKey: name, path }) => (
+                    <EuiTab
+                        key={id}
+                        isSelected={path === currentPath}
+                        onClick={() => router.push(path)}
+                    >
+                        {t(name)}
+                    </EuiTab>
+                ))}
+            </EuiTabs>
+            <EuiSpacer size="xxl" />
+            {children}
+        </>
+    );
+};

--- a/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
@@ -30,7 +30,10 @@ import { GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY } from '../../graphqlQueries';
 
 import { WFOMetadataPageLayout } from './WFOMetadataPageLayout';
 
+export const PRODUCT_BLOCK_FIELD_ID: keyof ProductBlockDefinition =
+    'productBlockId';
 export const PRODUCT_BLOCK_FIELD_NAME: keyof ProductBlockDefinition = 'name';
+
 export const PRODUCT_BLOCK_FIELD_TAG: keyof ProductBlockDefinition = 'tag';
 export const PRODUCT_BLOCK_FIELD_DESCRIPTION: keyof ProductBlockDefinition =
     'description';
@@ -42,8 +45,6 @@ export const PRODUCT_BLOCK_FIELD_END_DATE: keyof ProductBlockDefinition =
     'endDate';
 export const PRODUCT_BLOCK_FIELD_RESOURCE_TYPES: keyof ProductBlockDefinition =
     'resourceTypes';
-export const PRODUCT_BLOCK_FIELD_PARENT_IDS: keyof ProductBlockDefinition =
-    'parentIds';
 
 export const WFOProductBlocksPage = () => {
     const t = useTranslations('metadata.productBlocks');
@@ -63,6 +64,11 @@ export const WFOProductBlocksPage = () => {
         });
 
     const tableColumns: TableColumns<ProductBlockDefinition> = {
+        productBlockId: {
+            field: PRODUCT_BLOCK_FIELD_ID,
+            name: t('id'),
+            width: '110',
+        },
         name: {
             field: PRODUCT_BLOCK_FIELD_NAME,
             name: t('name'),
@@ -108,17 +114,6 @@ export const WFOProductBlocksPage = () => {
             name: t('endDate'),
             render: parseDateToLocaleString,
         },
-        parentIds: {
-            field: PRODUCT_BLOCK_FIELD_PARENT_IDS,
-            name: t('parentIds'),
-            render: (parentIds) => (
-                <>
-                    {parentIds.map((parentId, index) => (
-                        <div key={index}>{parentId}</div>
-                    ))}
-                </>
-            ),
-        },
     };
 
     const { data, isFetching } = useQueryWithGraphql(
@@ -137,7 +132,7 @@ export const WFOProductBlocksPage = () => {
         sortOrder: dataDisplayParams.sortBy?.order ?? SortOrder.ASC,
     };
 
-    const totalItems = data?.results.pageInfo.totalItems;
+    const totalItems = data?.productBlocks.pageInfo.totalItems;
 
     const pagination: Pagination = {
         pageSize: dataDisplayParams.pageSize,
@@ -149,7 +144,7 @@ export const WFOProductBlocksPage = () => {
     return (
         <WFOMetadataPageLayout>
             <TableWithFilter<ProductBlockDefinition>
-                data={data ? data.results.page : []}
+                data={data ? data.productBlocks.page : []}
                 tableColumns={tableColumns}
                 dataSorting={dataSorting}
                 onUpdateDataSort={getDataSortHandler<ProductBlockDefinition>(

--- a/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
@@ -110,7 +110,7 @@ export const WFOProductBlocksPage = () => {
         },
         parentIds: {
             field: PRODUCT_BLOCK_FIELD_PARENT_IDS,
-            name: t('endDate'),
+            name: t('parentIds'),
             render: (parentIds) => (
                 <>
                     {parentIds.map((parentId, index) => (

--- a/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { WFOMetadataPageLayout } from './WFOMetadataPageLayout';
+
+export const WFOProductBlocksPage = () => {
+    return (
+        <WFOMetadataPageLayout>
+            <div>ProductBLOCKSpaGE!!!!123</div>;
+        </WFOMetadataPageLayout>
+    );
+};

--- a/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WFOProductBlocksPage.tsx
@@ -1,10 +1,172 @@
 import React from 'react';
+import { useTranslations } from 'next-intl';
+import type { Pagination } from '@elastic/eui/src/components';
+
+import {
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_PAGE_SIZES,
+    METADATA_PRODUCTBLOCKS_TABLE_LOCAL_STORAGE_KEY,
+} from '../../components';
+import {
+    WFOStatusBadge,
+    WFOProductBlockBadge,
+    TableWithFilter,
+} from '../../components';
+import {
+    getTableConfigFromLocalStorage,
+    getDataSortHandler,
+    getPageChangeHandler,
+    getEsQueryStringHandler,
+} from '../../components';
+import type { TableColumns, DataSorting } from '../../components';
+
+import { parseDateToLocaleString } from '../../utils';
+import type { ProductBlockDefinition } from '../../types';
+import { SortOrder } from '../../types';
+
+import { useDataDisplayParams, useQueryWithGraphql } from '../../hooks';
+
+import { GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY } from '../../graphqlQueries';
+
 import { WFOMetadataPageLayout } from './WFOMetadataPageLayout';
 
+export const PRODUCT_BLOCK_FIELD_NAME: keyof ProductBlockDefinition = 'name';
+export const PRODUCT_BLOCK_FIELD_TAG: keyof ProductBlockDefinition = 'tag';
+export const PRODUCT_BLOCK_FIELD_DESCRIPTION: keyof ProductBlockDefinition =
+    'description';
+export const PRODUCT_BLOCK_FIELD_STATUS: keyof ProductBlockDefinition =
+    'status';
+export const PRODUCT_BLOCK_FIELD_CREATED_AT: keyof ProductBlockDefinition =
+    'createdAt';
+export const PRODUCT_BLOCK_FIELD_END_DATE: keyof ProductBlockDefinition =
+    'endDate';
+export const PRODUCT_BLOCK_FIELD_RESOURCE_TYPES: keyof ProductBlockDefinition =
+    'resourceTypes';
+export const PRODUCT_BLOCK_FIELD_PARENT_IDS: keyof ProductBlockDefinition =
+    'parentIds';
+
 export const WFOProductBlocksPage = () => {
+    const t = useTranslations('metadata.productBlocks');
+
+    const initialPageSize =
+        getTableConfigFromLocalStorage(
+            METADATA_PRODUCTBLOCKS_TABLE_LOCAL_STORAGE_KEY,
+        )?.selectedPageSize ?? DEFAULT_PAGE_SIZE;
+
+    const { dataDisplayParams, setDataDisplayParam } =
+        useDataDisplayParams<ProductBlockDefinition>({
+            pageSize: initialPageSize,
+            sortBy: {
+                field: PRODUCT_BLOCK_FIELD_NAME,
+                order: SortOrder.ASC,
+            },
+        });
+
+    const tableColumns: TableColumns<ProductBlockDefinition> = {
+        name: {
+            field: PRODUCT_BLOCK_FIELD_NAME,
+            name: t('name'),
+            width: '110',
+        },
+        description: {
+            field: PRODUCT_BLOCK_FIELD_DESCRIPTION,
+            name: t('description'),
+            width: '400',
+        },
+        tag: {
+            field: PRODUCT_BLOCK_FIELD_TAG,
+            name: t('tag'),
+        },
+        status: {
+            field: PRODUCT_BLOCK_FIELD_STATUS,
+            name: t('status'),
+            width: '90',
+            render: (value) => (
+                <WFOStatusBadge status={value.toLocaleLowerCase()} />
+            ),
+        },
+        resourceTypes: {
+            field: PRODUCT_BLOCK_FIELD_RESOURCE_TYPES,
+            name: t('resourceTypes'),
+            render: (resourceTypes) => (
+                <>
+                    {resourceTypes.map((resourceType, index) => (
+                        <WFOProductBlockBadge key={index}>
+                            {resourceType.resourceType}
+                        </WFOProductBlockBadge>
+                    ))}
+                </>
+            ),
+        },
+        createdAt: {
+            field: PRODUCT_BLOCK_FIELD_CREATED_AT,
+            name: t('createdAt'),
+            render: parseDateToLocaleString,
+        },
+        endDate: {
+            field: PRODUCT_BLOCK_FIELD_END_DATE,
+            name: t('endDate'),
+            render: parseDateToLocaleString,
+        },
+        parentIds: {
+            field: PRODUCT_BLOCK_FIELD_PARENT_IDS,
+            name: t('endDate'),
+            render: (parentIds) => (
+                <>
+                    {parentIds.map((parentId, index) => (
+                        <div key={index}>{parentId}</div>
+                    ))}
+                </>
+            ),
+        },
+    };
+
+    const { data, isFetching } = useQueryWithGraphql(
+        GET_PRODUCTS_BLOCKS_GRAPHQL_QUERY,
+        {
+            first: dataDisplayParams.pageSize,
+            after: dataDisplayParams.pageIndex * dataDisplayParams.pageSize,
+            sortBy: dataDisplayParams.sortBy,
+        },
+        'productBlocks',
+        true,
+    );
+
+    const dataSorting: DataSorting<ProductBlockDefinition> = {
+        field: dataDisplayParams.sortBy?.field ?? PRODUCT_BLOCK_FIELD_NAME,
+        sortOrder: dataDisplayParams.sortBy?.order ?? SortOrder.ASC,
+    };
+
+    const totalItems = data?.results.pageInfo.totalItems;
+
+    const pagination: Pagination = {
+        pageSize: dataDisplayParams.pageSize,
+        pageIndex: dataDisplayParams.pageIndex,
+        pageSizeOptions: DEFAULT_PAGE_SIZES,
+        totalItemCount: totalItems ? totalItems : 0,
+    };
+
     return (
         <WFOMetadataPageLayout>
-            <div>ProductBLOCKSpaGE!!!!123</div>;
+            <TableWithFilter<ProductBlockDefinition>
+                data={data ? data.results.page : []}
+                tableColumns={tableColumns}
+                dataSorting={dataSorting}
+                onUpdateDataSort={getDataSortHandler<ProductBlockDefinition>(
+                    dataDisplayParams,
+                    setDataDisplayParam,
+                )}
+                onUpdatePage={getPageChangeHandler<ProductBlockDefinition>(
+                    setDataDisplayParam,
+                )}
+                onUpdateEsQueryString={getEsQueryStringHandler<ProductBlockDefinition>(
+                    setDataDisplayParam,
+                )}
+                pagination={pagination}
+                isLoading={isFetching}
+                esQueryString={dataDisplayParams.esQueryString}
+                localStorageKey={METADATA_PRODUCTBLOCKS_TABLE_LOCAL_STORAGE_KEY}
+            />
         </WFOMetadataPageLayout>
     );
 };

--- a/packages/orchestrator-ui-components/src/pages/metadata/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './ProductBlocksPage'

--- a/packages/orchestrator-ui-components/src/pages/metadata/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/metadata/index.ts
@@ -1,1 +1,1 @@
-export * from './ProductBlocksPage';
+export * from './WFOProductBlocksPage';

--- a/packages/orchestrator-ui-components/src/pages/metadata/index.ts
+++ b/packages/orchestrator-ui-components/src/pages/metadata/index.ts
@@ -1,1 +1,1 @@
-export * from './ProductBlocksPage'
+export * from './ProductBlocksPage';

--- a/packages/orchestrator-ui-components/src/types.ts
+++ b/packages/orchestrator-ui-components/src/types.ts
@@ -43,6 +43,7 @@ export interface ResourceTypeDefinition {
 }
 
 export interface ProductBlockDefinition {
+    productBlockId: string;
     name: string;
     tag: string;
     description: string;
@@ -50,10 +51,21 @@ export interface ProductBlockDefinition {
     createdAt: Date | null;
     endDate: Date | null;
     resourceTypes: ResourceTypeDefinition[];
-    parentIds: string[];
 }
 
 export type FixedInputsBase = GenericField;
+
+export interface FixedInputDefinition {
+    fixedInputId: string;
+    name: string;
+    value: string;
+    productId: string;
+    createdAt: string;
+
+    // Display only?
+    description: string;
+    required: boolean;
+}
 
 export type ExternalServiceBase = {
     externalServiceKey: string;
@@ -117,23 +129,21 @@ export interface Process {
     is_task: boolean;
 }
 
-//// Utility types
-
-export interface Product {
+export interface ProductDefinition {
+    productId: string;
     name: string;
     description: string;
     tag: string;
+    createdAt: string;
     productType: string;
     status: string;
-    productBlocks: ProductBlock[];
-    createdAt: Date | null;
-}
-
-interface ProductBlock {
-    name: string;
+    productBlocks: Pick<ProductBlockDefinition, 'name'>[];
+    fixedInputs: Pick<FixedInputDefinition, 'name' | 'value'>[];
 }
 
 export type Field<Type> = keyof Type;
+
+//// Utility types
 
 export enum SortOrder {
     ASC = 'ASC',
@@ -157,16 +167,25 @@ export type GraphqlQueryVariables<Type> = {
     filterBy?: GraphqlFilter<Type>[];
 };
 
-export interface GraphQLResult<T> {
-    results: {
-        page: T[];
-        pageInfo: {
-            hasNextPage: boolean;
-            hasPreviousPage: boolean;
-            startCursor: number;
-            totalItems: number;
-            endCursor: number;
-        };
+type GraphQLPageInfo = {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: number;
+    totalItems: number;
+    endCursor: number;
+};
+
+export interface ProductDefinitionsResult {
+    products: {
+        page: ProductDefinition[];
+        pageInfo: GraphQLPageInfo;
+    };
+}
+
+export interface ProductBlockDefinitionsResult {
+    productBlocks: {
+        page: ProductBlockDefinition[];
+        pageInfo: GraphQLPageInfo;
     };
 }
 

--- a/packages/orchestrator-ui-components/src/types.ts
+++ b/packages/orchestrator-ui-components/src/types.ts
@@ -36,6 +36,23 @@ export type ProductBlockBase = {
     resourceTypes: ResourceTypeBase;
 };
 
+export interface ResourceTypeDefinition {
+    description: string;
+    resourceType: string;
+    resourceTypeId: string;
+}
+
+export interface ProductBlockDefinition {
+    name: string;
+    tag: string;
+    description: string;
+    status: string;
+    createdAt: Date | null;
+    endDate: Date | null;
+    resourceTypes: ResourceTypeDefinition[];
+    parentIds: string[];
+}
+
 export type FixedInputsBase = GenericField;
 
 export type ExternalServiceBase = {
@@ -139,6 +156,19 @@ export type GraphqlQueryVariables<Type> = {
     sortBy?: GraphQLSort<Type>;
     filterBy?: GraphqlFilter<Type>[];
 };
+
+export interface GraphQLResult<T> {
+    results: {
+        page: T[];
+        pageInfo: {
+            hasNextPage: boolean;
+            hasPreviousPage: boolean;
+            startCursor: number;
+            totalItems: number;
+            endCursor: number;
+        };
+    };
+}
 
 export interface CacheOption {
     value: string;


### PR DESCRIPTION
### Summary
Creates the metadata product blocks page and move the page from the app into the package. 

Contains changes to the metadata product page that are part of one of these tickets but are added here to make the commit hoooks pass:
Productspage: https://github.com/workfloworchestrator/orchestrator-ui/issues/150
Fixed inputs: https://github.com/workfloworchestrator/orchestrator-ui/issues/88
### DOD Tasks

- NA: Add/Update documentation.
- NA: Update CHANGELOG.md.
- NA: Affected functionality covered by system tests.