### PR TITLE
110 Streamlines release process

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,3 +6,42 @@ find the full documentation for it [in our repository](https://github.com/change
 
 We have a quick list of common questions to get you started engaging with this project in
 [our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)
+
+# Usage in project
+
+### Preparing the release
+
+```bash
+yarn changeset
+```
+
+-   Selecting packages that will get a version bump and, in a later step, being published
+-   Specifies per selected package the type of version bump (`major`, `minor` or `patch`)
+-   Adds a description or release notes for the release
+-   All entries will be saved in a `.md` file in the `.changeset` folder
+
+### Processing changes
+
+```bash
+yarn changeset version
+```
+
+-   Applies version bump in the selected packages
+-   Removes the `.md` file from the `.changset` folder
+
+### Publishing changes
+
+```bash
+yarn changeset publish
+```
+
+-   Performs the actual publish to npm
+-   This step also creates git tags, push them to git with `git push --follow-tags`
+
+### The TLDR
+
+```
+yarn changeset
+yarn changeset version
+yarn changeset publish
+```

--- a/.changeset/modern-olives-eat.md
+++ b/.changeset/modern-olives-eat.md
@@ -1,5 +1,0 @@
----
-'@orchestrator-ui/orchestrator-ui-components': patch
----
-
-Updates metadata pages and adds initial version of process-list page

--- a/.changeset/modern-olives-eat.md
+++ b/.changeset/modern-olives-eat.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+Updates metadata pages and adds initial version of process-list page

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -30,7 +30,7 @@ jobs:
               id: changesets
               uses: changesets/action@v1
               with:
-                  publish: yarn run publish-packages
+                  publish: yarn run packages:publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,5 +1,9 @@
 name: Publish to NPM
-on: [workflow_dispatch]
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - "main"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,5 +1,8 @@
 name: Publish to NPM
 on: [workflow_dispatch]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
     publish:
         runs-on: ubuntu-latest
@@ -23,14 +26,11 @@ jobs:
                 NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Installing dependencies
               run: yarn install --frozen-lockfile
-            - name: Processing changes
-              run: yarn changeset version
-            - name: Publishing changes
-              run: yarn changeset publish
-            - name: Adding version bumps and tags to GIT
-              run: |
-                git config user.name github-actions-publish-to-npm
-                git config user.email github-actions@github.com
-                git add .
-                git commit -m "Github Actions: Updates packages and publish to npm" --no-verify
-                git push --follow-tags
+            - name: Create Release Pull Request or Publish
+              id: changesets
+              uses: changesets/action@v1
+              with:
+                  publish: yarn run publish-packages
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,36 +12,13 @@ turbo dev
 ### Preparing the release
 
 ```bash
-yarn changeset
+yarn run packages:changeset
 ```
 
--   Selecting packages that will get a version bump and, in a later step, being published
+-   Include the changes made by this command in pull requests to the main branch
+-   Selecting packages that will get a version bump
 -   Specifies per selected package the type of version bump (`major`, `minor` or `patch`)
 -   Adds a description or release notes for the release
 -   All entries will be saved in a `.md` file in the `.changeset` folder
 
-### Processing changes
-
-```bash
-yarn changeset version
-```
-
--   Applies version bump in the selected packages
--   Removes the `.md` file from the `.changset` folder
-
-### Publishing changes
-
-```bash
-yarn changeset publish
-```
-
--   Performs the actual publish to npm
--   This step also creates git tags, push them to git with `git push --follow-tags`
-
-### The TLDR
-
-```
-yarn changeset
-yarn changeset version
-yarn changeset publish
-```
+Once the pull request with a changeset file is merged to the main branch another PR is opened by the Changesets-bot to update the version numbers of the packages. When this pull request gets merged to main an automatic publish to NPM will be performed.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "prettier": "prettier -c \"{**/*,*}.{ts,tsx,json,js,md}\"",
         "prettier-fix": "prettier --write \"{**/*,*}.{ts,tsx,json,js,md}\"",
         "build": "turbo run build",
-        "publish-packages": "turbo run build lint test && changeset publish",
+        "packages:changeset": "changeset",
+        "packages:publish": "turbo run build lint test && changeset publish",
         "prepare": "husky install"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "prettier": "prettier -c \"{**/*,*}.{ts,tsx,json,js,md}\"",
         "prettier-fix": "prettier --write \"{**/*,*}.{ts,tsx,json,js,md}\"",
         "build": "turbo run build",
-        "publish-packages": "turbo run build lint test && changeset version && changeset publish",
+        "publish-packages": "turbo run build lint test && changeset publish",
         "prepare": "husky install"
     },
     "devDependencies": {

--- a/packages/orchestrator-ui-components/CHANGELOG.md
+++ b/packages/orchestrator-ui-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @orchestrator-ui/orchestrator-ui-components
 
+## 0.2.2
+
+### Patch Changes
+
+- f49382c: Updates metadata pages and adds initial version of process-list page
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/orchestrator-ui-components/package.json
+++ b/packages/orchestrator-ui-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orchestrator-ui/orchestrator-ui-components",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "license": "MIT",
     "scripts": {
         "test": "jest",


### PR DESCRIPTION
https://github.com/workfloworchestrator/orchestrator-ui/issues/110

Using the Changesets github action combined with the changeset-bot.
1) Include a changeset in any PR towards main branch
2) When the main branch contains a changeset-file, changeset-bot opens a PR processing the version bumps to the package.json files
3) Afther merging that last PR, the bumped packages will be published to NPM