### PR TITLE
211 fix render details console error

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOKeyValueTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOKeyValueTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, Fragment, ReactNode } from 'react';
 import { useOrchestratorTheme } from '../../hooks';
 import { getStyles } from './styles';
 import { WFOKeyCell } from './WFOKeyCell';
@@ -25,7 +25,7 @@ export const WFOKeyValueTable: FC<WFOKeyValueTableProps> = ({
     return (
         <div css={keyValueTable}>
             {keyValues.map(({ key, value, plainTextValue }, rowNumber) => (
-                <>
+                <Fragment key={key}>
                     <WFOKeyCell value={key} rowNumber={rowNumber} />
                     <WFOValueCell
                         value={value}
@@ -33,7 +33,7 @@ export const WFOKeyValueTable: FC<WFOKeyValueTableProps> = ({
                         rowNumber={rowNumber}
                         enableCopyIcon={showCopyToClipboardIcon}
                     />
-                </>
+                </Fragment>
             ))}
         </div>
     );

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOBasicTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOBasicTable.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { EuiBasicTable, EuiBasicTableColumn, Pagination } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
-import { WFOTableHeaderCell } from './WFOTableHeaderCell';
+import { WFOTableHeaderCell } from '../WFOTableHeaderCell';
 
 import type {
     WFODataSorting,
     TableColumnKeys,
     WFOTableColumns,
     WFOTableColumnsWithControlColumns,
-} from './utils/columns';
+} from '../utils/columns';
 
-export type WFOTableProps<T> = {
+export type WFOBasicTableProps<T> = {
     data: T[];
     columns: WFOTableColumnsWithControlColumns<T> | WFOTableColumns<T>;
     hiddenColumns?: TableColumnKeys<T>;
@@ -21,7 +21,7 @@ export type WFOTableProps<T> = {
     onDataSort?: (columnId: keyof T) => void;
 };
 
-export const WFOTable = <T,>({
+export const WFOBasicTable = <T,>({
     data,
     columns,
     hiddenColumns,
@@ -30,10 +30,10 @@ export const WFOTable = <T,>({
     isLoading,
     onCriteriaChange,
     onDataSort,
-}: WFOTableProps<T>) => (
+}: WFOBasicTableProps<T>) => (
     <EuiBasicTable
         items={data}
-        columns={mapTableColumnsToEuiColumns(
+        columns={mapWFOTableColumnsToEuiColumns(
             columns,
             hiddenColumns,
             dataSorting,
@@ -45,8 +45,8 @@ export const WFOTable = <T,>({
     />
 );
 
-function mapTableColumnsToEuiColumns<T>(
-    columns: WFOTableColumns<T>,
+function mapWFOTableColumnsToEuiColumns<T>(
+    tableColumns: WFOTableColumns<T>,
     hiddenColumns?: TableColumnKeys<T>,
     dataSorting?: WFODataSorting<T>,
     onDataSort?: (columnId: keyof T) => void,
@@ -55,10 +55,11 @@ function mapTableColumnsToEuiColumns<T>(
         return !hiddenColumns?.includes(columnKey as keyof T);
     }
 
-    function mapToEuiColumn(colKey: string): EuiBasicTableColumn<T> {
+    function mapColumnKeyToEuiColumn(colKey: string): EuiBasicTableColumn<T> {
         const typedColumnKey = colKey as keyof T;
-        const column = columns[typedColumnKey];
-        const { name } = column;
+        const column: WFOTableColumns<T>[keyof T] =
+            tableColumns[typedColumnKey];
+        const { name, render, width, description } = column;
 
         const sortDirection =
             dataSorting?.field === colKey ? dataSorting.sortOrder : undefined;
@@ -66,7 +67,9 @@ function mapTableColumnsToEuiColumns<T>(
         const handleClick = () => onDataSort?.(typedColumnKey);
 
         return {
-            ...column,
+            render,
+            width,
+            description,
             field: typedColumnKey,
             name: name && (
                 <WFOTableHeaderCell
@@ -81,5 +84,7 @@ function mapTableColumnsToEuiColumns<T>(
         };
     }
 
-    return Object.keys(columns).filter(isVisibleColumn).map(mapToEuiColumn);
+    return Object.keys(tableColumns)
+        .filter(isVisibleColumn)
+        .map(mapColumnKeyToEuiColumn);
 }

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOSortDirectionIcon.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOSortDirectionIcon.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from 'react';
-import { useOrchestratorTheme } from '../../hooks/useOrchestratorTheme';
-import { WFOArrowNarrowDown } from '../../icons/WFOArrowNarrowDown';
-import { WFOArrowNarrowUp } from '../../icons/WFOArrowNarrowUp';
-import { SortOrder } from '../../types';
+import { useOrchestratorTheme } from '../../../hooks';
+import { WFOArrowNarrowDown, WFOArrowNarrowUp } from '../../../icons';
+import { SortOrder } from '../../../types';
 
 export type WFOSortDirectionIconProps = {
     sortDirection: SortOrder;

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOTableHeaderCell.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOTableHeaderCell.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 
-import { SortOrder } from '../../types';
+import { SortOrder } from '../../../types';
 import { WFOSortDirectionIcon } from './WFOSortDirectionIcon';
 
 export type WFOTableHeaderCellProps = {

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/index.ts
@@ -1,0 +1,1 @@
+export * from './WFOBasicTable';

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/index.ts
@@ -1,1 +1,3 @@
 export * from './WFOBasicTable';
+export * from './WFOSortDirectionIcon';
+export * from './WFOTableHeaderCell';

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOTableWithFilter/WFOTableWithFilter.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOTableWithFilter/WFOTableWithFilter.tsx
@@ -21,7 +21,7 @@ import {
     TableSettingsModal,
 } from '../WFOTableSettingsModal';
 import { WFOSearchField } from '../../WFOSearchBar';
-import { WFOTable } from '../WFOTable';
+import { WFOBasicTable } from '../WFOBasicTable';
 import { DEFAULT_PAGE_SIZES } from '../utils/constants';
 import {
     clearTableConfigFromLocalStorage,
@@ -202,7 +202,7 @@ export const WFOTableWithFilter = <T,>({
                 </EuiButton>
             </EuiFlexGroup>
             <EuiSpacer size="m" />
-            <WFOTable
+            <WFOBasicTable
                 data={data}
                 columns={tableColumnsWithControlColumns}
                 hiddenColumns={hiddenColumns}

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOTableWithFilter/WFOTableWithFilter.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOTableWithFilter/WFOTableWithFilter.tsx
@@ -11,7 +11,6 @@ import {
     WFODataSorting,
     TableColumnKeys,
     WFOTableColumns,
-    WFOTableColumnsWithControlColumns,
     WFOTableControlColumnConfig,
     WFOTableDataColumnConfig,
 } from '../utils/columns';
@@ -21,7 +20,10 @@ import {
     TableSettingsModal,
 } from '../WFOTableSettingsModal';
 import { WFOSearchField } from '../../WFOSearchBar';
-import { WFOBasicTable } from '../WFOBasicTable';
+import {
+    WFOBasicTable,
+    WFOBasicTableColumnsWithControlColumns,
+} from '../WFOBasicTable';
 import { DEFAULT_PAGE_SIZES } from '../utils/constants';
 import {
     clearTableConfigFromLocalStorage,
@@ -109,7 +111,7 @@ export const WFOTableWithFilter = <T,>({
         },
     };
 
-    const tableColumnsWithControlColumns: WFOTableColumnsWithControlColumns<T> =
+    const tableColumnsWithControlColumns: WFOBasicTableColumnsWithControlColumns<T> =
         {
             ...leadingControlColumns,
             ...tableColumns,

--- a/packages/orchestrator-ui-components/src/components/WFOTable/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/index.ts
@@ -11,4 +11,3 @@ export * from './utils/tableUtils';
 
 export * from './WFOBasicTable';
 export * from './WFOTableWithFilter';
-export * from './WFOTableHeaderCell';

--- a/packages/orchestrator-ui-components/src/components/WFOTable/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/index.ts
@@ -9,6 +9,6 @@ export * from './utils/constants';
 export * from './utils/tableConfigPersistence';
 export * from './utils/tableUtils';
 
-export * from './WFOTable';
+export * from './WFOBasicTable';
 export * from './WFOTableWithFilter';
 export * from './WFOTableHeaderCell';

--- a/packages/orchestrator-ui-components/src/components/WFOTable/utils/columns.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/utils/columns.ts
@@ -4,12 +4,13 @@ import { SortOrder } from '../../../types';
 
 // Todo need to Pick a few more props from EuiBasicTableColumn to prevent none-functioning props (truncateText)
 // https://github.com/workfloworchestrator/orchestrator-ui/issues/130
-export type WFOBasicTableColumn<T> = Omit<EuiBasicTableColumn<T>, 'render'>;
+export type WFOEuiBasicTableColumn<T> = Omit<EuiBasicTableColumn<T>, 'render'>;
 
-export type WFOTableDataColumnConfig<T, Property> = WFOBasicTableColumn<T> & {
-    field: Property;
-    name: string;
-};
+export type WFOTableDataColumnConfig<T, Property> =
+    WFOEuiBasicTableColumn<T> & {
+        field: Property;
+        name: string;
+    };
 
 // Todo need to Pick a few props from EuiBasicTableColumn to prevent none-functioning props (truncateText)
 export type WFOTableColumnsWithExtraNonDataFields<T> = WFOTableColumns<T> & {
@@ -28,15 +29,12 @@ export type WFOTableColumns<T> = {
 };
 
 export type WFOTableControlColumnConfig<T> = {
-    [key: string]: WFOBasicTableColumn<T> & {
+    [key: string]: WFOEuiBasicTableColumn<T> & {
         field: string;
         name?: string;
         render: (cellValue: never, row: T) => ReactNode;
     };
 };
-
-export type WFOTableColumnsWithControlColumns<T> = WFOTableColumns<T> &
-    WFOTableControlColumnConfig<T>;
 
 export type TableColumnKeys<T> = Array<keyof T>;
 


### PR DESCRIPTION
#211 

Changes in story #211 introduced a few console errors due to passing too many props to the table component of EUI.
This PR solves that issue, added a comment in the code why not to spread the column config and fixes another console error due to a missing key when mapping from an array to the key-value components.

Besides the fixes there is a small refactor and rename of the internal components of the WFOTable component