### PR TITLE
218 multiple tsconfigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build": "turbo run build",
         "packages:changeset": "changeset",
         "packages:publish": "turbo run build lint test && changeset publish",
-        "prepare": "husky install"
+        "prepare": "husky install && turbo run build --filter=./packages/*"
     },
     "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/packages/orchestrator-ui-components/package.json
+++ b/packages/orchestrator-ui-components/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "scripts": {
         "test": "jest",
-        "build": "tsup src/index.ts --format esm --dts",
+        "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
         "tsc": "tsc --noEmit",
         "lint": "eslint \"src/**/*.ts*\"",
         "dev": "yarn build -- --watch",

--- a/packages/orchestrator-ui-components/tsconfig.build.json
+++ b/packages/orchestrator-ui-components/tsconfig.build.json
@@ -1,11 +1,9 @@
 {
     "extends": "@orchestrator-ui/tsconfig/base.json",
     "compilerOptions": {
-        "strictNullChecks": true,
-        "rootDir": "./src",
-        "outDir": "./dist"
+        "strictNullChecks": true
     },
-    "include": ["./src/**/*.ts", "./src/**/*.tsx"],
+    "include": ["**/*.ts", "**/*.tsx"],
     "exclude": [
         "node_modules",
         "**/*.stories.ts",


### PR DESCRIPTION
This PR introduces a specific build tsconfig in the orchestrator. It resolves the go-to issue when clicking from the app on a component to go right to the source code in the package instead of its dist folder.
While running the dev-server it still depends on the dist folders, which is desired.

Building the packages in the prepare script is need to prevent welcoming the developer with all kinds of not-found errors.