### PR TITLE
WFO Table style update

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOBasicTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/WFOBasicTable.tsx
@@ -8,6 +8,8 @@ import {
     WFOTableControlColumnConfig,
     WFOTableDataColumnConfig,
 } from '../utils/columns';
+import { useOrchestratorTheme } from '../../../hooks';
+import { getStyles } from './styles';
 
 export type WFOBasicTableColumns<T> = {
     [Property in keyof T]: WFOTableDataColumnConfig<T, Property> & {
@@ -40,20 +42,26 @@ export const WFOBasicTable = <T,>({
     isLoading,
     onCriteriaChange,
     onDataSort,
-}: WFOBasicTableProps<T>) => (
-    <EuiBasicTable
-        items={data}
-        columns={mapWFOTableColumnsToEuiColumns(
-            columns,
-            hiddenColumns,
-            dataSorting,
-            onDataSort,
-        )}
-        pagination={pagination}
-        onChange={onCriteriaChange}
-        loading={isLoading}
-    />
-);
+}: WFOBasicTableProps<T>) => {
+    const { theme } = useOrchestratorTheme();
+    const { basicTableStyle } = getStyles(theme);
+
+    return (
+        <EuiBasicTable
+            css={basicTableStyle}
+            items={data}
+            columns={mapWFOTableColumnsToEuiColumns(
+                columns,
+                hiddenColumns,
+                dataSorting,
+                onDataSort,
+            )}
+            pagination={pagination}
+            onChange={onCriteriaChange}
+            loading={isLoading}
+        />
+    );
+};
 
 function mapWFOTableColumnsToEuiColumns<T>(
     tableColumns: WFOBasicTableColumns<T>,

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/styles.ts
@@ -1,0 +1,25 @@
+import { EuiThemeComputed } from '@elastic/eui/src/services/theme/types';
+import { css } from '@emotion/react';
+
+export const getStyles = (theme: EuiThemeComputed) => {
+    const radius = theme.border.radius.medium;
+
+    const basicTableStyle = css({
+        '.euiTableCellContent__text': {
+            display: 'flex',
+        },
+        thead: {
+            backgroundColor: theme.colors.lightShade,
+            'tr>:first-child': {
+                borderTopLeftRadius: radius,
+            },
+            'tr>:last-child': {
+                borderTopRightRadius: radius,
+            },
+        },
+    });
+
+    return {
+        basicTableStyle,
+    };
+};

--- a/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOTable/WFOBasicTable/styles.ts
@@ -17,6 +17,9 @@ export const getStyles = (theme: EuiThemeComputed) => {
                 borderTopRightRadius: radius,
             },
         },
+        'tr.euiTableRow:hover': {
+            backgroundColor: theme.colors.lightestShade,
+        },
     });
 
     return {


### PR DESCRIPTION
Some adjustments to make the table style match better with the design
- gray background table header
- slightly darker hover effect for the rows
- center vertically content in cells

![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/3a951b19-d1d7-461e-b94b-0a734fa670cb)
