### PR TITLE
276 - Listing products in the new subscription combobox instead of wo…

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WFOPageTemplate/WFOSidebar/WFOStartCreateWorkflowButtonComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOPageTemplate/WFOSidebar/WFOStartCreateWorkflowButtonComboBox.tsx
@@ -30,18 +30,24 @@ export const WFOStartCreateWorkflowButtonComboBox = () => {
             .flatMap(({ name: workflowName, products }) =>
                 products.map(({ productId, name: productName }) => ({
                     label: productName,
-                    itemID: `${workflowName}?productId=${productId}`,
+                    itemID: `${workflowName}/${productId}`,
                 })),
             )
             .sort((a, b) => a.label.localeCompare(b.label)) ?? [];
+
+    const handleOptionChange = (selectedProduct: ComboBoxOption) => {
+        const [workflowName, productId] = selectedProduct.itemID.split('/');
+        router.push({
+            pathname: `${PATH_START_WORKFLOW}/${workflowName}`,
+            query: { productId },
+        });
+    };
 
     return (
         <WFOButtonComboBox
             buttonText={t('newSubscription')}
             options={productList}
-            onOptionChange={(selectedProduct) =>
-                router.push(`${PATH_START_WORKFLOW}/${selectedProduct.itemID}`)
-            }
+            onOptionChange={handleOptionChange}
         />
     );
 };

--- a/packages/orchestrator-ui-components/src/components/WFOPageTemplate/WFOSidebar/WFOStartCreateWorkflowButtonComboBox.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOPageTemplate/WFOSidebar/WFOStartCreateWorkflowButtonComboBox.tsx
@@ -25,18 +25,22 @@ export const WFOStartCreateWorkflowButtonComboBox = () => {
         true,
     );
 
-    const options: ComboBoxOption[] =
-        data?.workflows.page.map(({ name, description }) => ({
-            itemID: name,
-            label: description ?? name,
-        })) ?? [];
+    const productList: ComboBoxOption[] =
+        data?.workflows.page
+            .flatMap(({ name: workflowName, products }) =>
+                products.map(({ productId, name: productName }) => ({
+                    label: productName,
+                    itemID: `${workflowName}?productId=${productId}`,
+                })),
+            )
+            .sort((a, b) => a.label.localeCompare(b.label)) ?? [];
 
     return (
         <WFOButtonComboBox
             buttonText={t('newSubscription')}
-            options={options}
-            onOptionChange={(selectedOption) =>
-                router.push(`${PATH_START_WORKFLOW}/${selectedOption.itemID}`)
+            options={productList}
+            onOptionChange={(selectedProduct) =>
+                router.push(`${PATH_START_WORKFLOW}/${selectedProduct.itemID}`)
             }
         />
     );

--- a/packages/orchestrator-ui-components/src/graphqlQueries/workflows/workflowsQueryForDropdownList.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/workflows/workflowsQueryForDropdownList.ts
@@ -8,7 +8,9 @@ import {
 } from '../../types';
 
 export const GET_WORKFLOWS_FOR_DROPDOWN_LIST_GRAPHQL_QUERY: TypedDocumentNode<
-    WorkflowDefinitionsResult<Pick<WorkflowDefinition, 'name' | 'description'>>,
+    WorkflowDefinitionsResult<
+        Pick<WorkflowDefinition, 'name' | 'description' | 'products'>
+    >,
     GraphqlQueryVariables<WorkflowDefinition>
 > = parse(gql`
     query CreateWorkflows(
@@ -20,6 +22,10 @@ export const GET_WORKFLOWS_FOR_DROPDOWN_LIST_GRAPHQL_QUERY: TypedDocumentNode<
             page {
                 name
                 description
+                products {
+                    productId
+                    name
+                }
             }
             pageInfo {
                 endCursor

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -237,7 +237,7 @@ export interface WorkflowDefinition {
     name: string;
     description?: string;
     target: WorkflowTarget;
-    products: Pick<ProductDefinition, 'tag'>[];
+    products: Pick<ProductDefinition, 'tag' | 'productId' | 'name'>[];
     createdAt: string;
 }
 


### PR DESCRIPTION
#276 

Instead of rendering a list of workflows, we need to render a list of products in these workflows. A workflow item can be applicable to one or more products.

Clicking on an item redirects the user to the start-workflow page with a parameter, for example:
`/start-workflow/create_ip_peer?productId=67cafaf9-3987-43f0-a4c9-54a11b028f8e`

![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/2275ba2d-fc1a-419e-85c5-1ae72b7ae0e0)

