### PR TITLE
Updates padding value and adds styles specific for key and value cells

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOKeyCell.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOKeyCell.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { useOrchestratorTheme } from '../../hooks';
 import { getStyles } from './styles';
+import { EuiText } from '@elastic/eui';
 
 export type WFOKeyCellProps = {
     value: string;
@@ -9,11 +10,14 @@ export type WFOKeyCellProps = {
 
 export const WFOKeyCell: FC<WFOKeyCellProps> = ({ value, rowNumber }) => {
     const { theme } = useOrchestratorTheme();
-    const { keyColumnStyle, getBackgroundColorStyleForRow } = getStyles(theme);
+    const { keyColumnStyle, keyCellStyle, getBackgroundColorStyleForRow } =
+        getStyles(theme);
 
     return (
         <div css={[getBackgroundColorStyleForRow(rowNumber), keyColumnStyle]}>
-            <b>{value}</b>
+            <EuiText css={keyCellStyle} size="s">
+                {value}
+            </EuiText>
         </div>
     );
 };

--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOValueCell.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/WFOValueCell.tsx
@@ -20,6 +20,7 @@ export const WFOValueCell: FC<WFOValueCellProps> = ({
     const { theme } = useOrchestratorTheme();
     const {
         valueColumnStyle,
+        valueCellStyle,
         clipboardIconStyle,
         clickable,
         getBackgroundColorStyleForRow,
@@ -29,7 +30,7 @@ export const WFOValueCell: FC<WFOValueCellProps> = ({
 
     return (
         <div css={[getBackgroundColorStyleForRow(rowNumber), valueColumnStyle]}>
-            <div>{value}</div>
+            <div css={valueCellStyle}>{value}</div>
             <div css={clipboardIconStyle}>
                 {shouldRenderCopyColumn && (
                     <EuiCopy textToCopy={textToCopy}>

--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
@@ -2,7 +2,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { EuiThemeComputed } from '@elastic/eui/src/services/theme/types';
 
 export const getStyles = (theme: EuiThemeComputed) => {
-    const padding = theme.font.baseline * 2;
+    const padding = theme.font.baseline * 2.5;
     const clipboardIconMargin = theme.font.baseline * 2;
     const keyColumnWidth = theme.base * 12;
     const radius = theme.border.radius.medium;
@@ -40,6 +40,16 @@ export const getStyles = (theme: EuiThemeComputed) => {
         },
     });
 
+    const keyCellStyle = css({
+        fontWeight: theme.font.weight.semiBold,
+        color: theme.colors.title,
+    });
+
+    const valueCellStyle = css({
+        fontWeight: theme.font.weight.regular,
+        color: theme.colors.text,
+    });
+
     const clipboardIconStyle = css({
         visibility: 'hidden',
         paddingBottom: 0,
@@ -54,6 +64,8 @@ export const getStyles = (theme: EuiThemeComputed) => {
         keyValueTable,
         keyColumnStyle,
         valueColumnStyle,
+        keyCellStyle,
+        valueCellStyle,
         clipboardIconStyle,
         clickable,
         lightBackground,

--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
@@ -48,6 +48,8 @@ export const getStyles = (theme: EuiThemeComputed) => {
     const valueCellStyle = css({
         fontWeight: theme.font.weight.regular,
         color: theme.colors.text,
+        display: 'flex',
+        alignItems: 'center',
     });
 
     const clipboardIconStyle = css({

--- a/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WFOKeyValueTable/styles.ts
@@ -41,7 +41,7 @@ export const getStyles = (theme: EuiThemeComputed) => {
     });
 
     const keyCellStyle = css({
-        fontWeight: theme.font.weight.semiBold,
+        fontWeight: theme.font.weight.medium,
         color: theme.colors.title,
     });
 


### PR DESCRIPTION
Some style fixes for keyValue table
Note: the font weight of the key is not matching the design. Using "semibold" instead of "medium". Using "medium" does not result in a visible difference between the keys and values in the table. 

![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/f79f9203-a5cc-4b22-8b8b-2c92435ac86f)

![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/f12f0f8f-5d07-469a-89e9-28595f9626d8)
