### PR TITLE
366 failedtask engine badge

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
@@ -12,45 +12,23 @@ export const WfoEngineStatusBadge = () => {
         ? `Engine is ${engineStatus.global_status}`
         : 'Engine status is unavailable';
 
-    // if (data: engineStatus === "RUNNING") {
+    // if (engineStatus?.global_status === "RUNNING") {
     //     const engineColor = theme.colors.success
     // } else {
     //     const engineColor = theme.colors.danger
     // }
-    //
-    // return (
-    //     <WfoHeaderBadge
-    //         color={theme.colors.emptyShade}
-    //         textColor={theme.colors.shadow}
-    //         iconType={() => <WFOStatusDotIcon color={engineColor} />}
-    //     >
-    //         {engineStatusText}
-    //     </WfoHeaderBadge>
-    // );
+    const engineColor =
+        engineStatus?.global_status === 'RUNNING'
+            ? theme.colors.success
+            : theme.colors.danger;
 
-    if (engineStatus?.global_status == 'RUNNING') {
-        return (
-            <WfoHeaderBadge
-                color={theme.colors.emptyShade}
-                textColor={theme.colors.shadow}
-                iconType={() => (
-                    <WfoStatusDotIcon color={theme.colors.success} />
-                )}
-            >
-                {engineStatusText}
-            </WfoHeaderBadge>
-        );
-    } else {
-        return (
-            <WfoHeaderBadge
-                color={theme.colors.emptyShade}
-                textColor={theme.colors.shadow}
-                iconType={() => (
-                    <WfoStatusDotIcon color={theme.colors.danger} />
-                )}
-            >
-                {engineStatusText}
-            </WfoHeaderBadge>
-        );
-    }
+    return (
+        <WfoHeaderBadge
+            color={theme.colors.emptyShade}
+            textColor={theme.colors.shadow}
+            iconType={() => <WfoStatusDotIcon color={engineColor} />}
+        >
+            {engineStatusText}
+        </WfoHeaderBadge>
+    );
 };

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
@@ -12,13 +12,45 @@ export const WfoEngineStatusBadge = () => {
         ? `Engine is ${engineStatus.global_status}`
         : 'Engine status is unavailable';
 
-    return (
-        <WfoHeaderBadge
-            color={theme.colors.emptyShade}
-            textColor={theme.colors.shadow}
-            iconType={() => <WfoStatusDotIcon color={theme.colors.success} />}
-        >
-            {engineStatusText}
-        </WfoHeaderBadge>
-    );
+    // if (engineStatus === engineStatus?.global) {
+    //     const engineColor = theme.colors.success
+    // } else {
+    //     const engineColor = theme.colors.danger
+    // }
+    //
+    // return (
+    //     <WfoHeaderBadge
+    //         color={theme.colors.emptyShade}
+    //         textColor={theme.colors.shadow}
+    //         iconType={() => <WFOStatusDotIcon color={engineColor} />}
+    //     >
+    //         {engineStatusText}
+    //     </WfoHeaderBadge>
+    // );
+
+    if (engineStatus?.global_status == 'RUNNING') {
+        return (
+            <WfoHeaderBadge
+                color={theme.colors.emptyShade}
+                textColor={theme.colors.shadow}
+                iconType={() => (
+                    <WfoStatusDotIcon color={theme.colors.success} />
+                )}
+            >
+                {engineStatusText}
+            </WfoHeaderBadge>
+        );
+    } else {
+        return (
+            <WfoHeaderBadge
+                color={theme.colors.emptyShade}
+                textColor={theme.colors.shadow}
+                iconType={() => (
+                    <WfoStatusDotIcon color={theme.colors.danger} />
+                )}
+            >
+                {engineStatusText}
+            </WfoHeaderBadge>
+        );
+    }
 };

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
@@ -12,11 +12,6 @@ export const WfoEngineStatusBadge = () => {
         ? `Engine is ${engineStatus.global_status}`
         : 'Engine status is unavailable';
 
-    // if (engineStatus?.global_status === "RUNNING") {
-    //     const engineColor = theme.colors.success
-    // } else {
-    //     const engineColor = theme.colors.danger
-    // }
     const engineColor =
         engineStatus?.global_status === 'RUNNING'
             ? theme.colors.success

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoEngineStatusBadge/WfoEngineStatusBadge.tsx
@@ -12,7 +12,7 @@ export const WfoEngineStatusBadge = () => {
         ? `Engine is ${engineStatus.global_status}`
         : 'Engine status is unavailable';
 
-    // if (engineStatus === engineStatus?.global) {
+    // if (data: engineStatus === "RUNNING") {
     //     const engineColor = theme.colors.success
     // } else {
     //     const engineColor = theme.colors.danger

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
@@ -7,6 +7,7 @@ import {
     ProcessStatusCounts,
     useProcessStatusCountsQuery,
 } from '../../../hooks/useProcessStatusCountsQuery';
+import { WfoCheckmarkCircleFill } from '../../../icons';
 
 type TaskCountsSummary = {
     failed: number;
@@ -36,28 +37,80 @@ export const WfoFailedTasksBadge = () => {
     const { data: processStatusCounts } = useProcessStatusCountsQuery();
     const taskCountsSummary = getTaskCountsSummary(processStatusCounts);
 
-    return (
-        <EuiToolTip
-            position="bottom"
-            content={
-                <>
-                    <div>Failed: {taskCountsSummary.failed}</div>
-                    <div>
-                        Inconsistent data: {taskCountsSummary.inconsistentData}
-                    </div>
-                    <div>
-                        API unavailable: {taskCountsSummary.apiUnavailable}
-                    </div>
-                </>
-            }
-        >
-            <WfoHeaderBadge
-                color={theme.colors.emptyShade}
-                textColor={theme.colors.shadow}
-                iconType={() => <WfoXCircleFill color={theme.colors.danger} />}
+    // <<<<<<< HEAD:packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
+    //     return (
+    //         <EuiToolTip
+    //             position="bottom"
+    //             content={
+    //                 <>
+    //                     <div>Failed: {taskCountsSummary.failed}</div>
+    //                     <div>
+    //                         Inconsistent data: {taskCountsSummary.inconsistentData}
+    //                     </div>
+    //                     <div>
+    //                         API unavailable: {taskCountsSummary.apiUnavailable}
+    //                     </div>
+    //                 </>
+    //             }
+    //         >
+    //             <WfoHeaderBadge
+    //                 color={theme.colors.emptyShade}
+    //                 textColor={theme.colors.shadow}
+    //                 iconType={() => <WfoXCircleFill color={theme.colors.danger} />}
+    //             >
+    //                 {taskCountsSummary.total}
+    //             </WfoHeaderBadge>
+    //         </EuiToolTip>
+    //     );
+    // =======
+    if (taskCountsSummary.total != 0) {
+        return (
+            <EuiToolTip
+                position="bottom"
+                content={
+                    <>
+                        <div>Failed: {taskCountsSummary.failed}</div>
+                        <div>
+                            Inconsistent data:{' '}
+                            {taskCountsSummary.inconsistentData}
+                        </div>
+                        <div>
+                            API unavailable: {taskCountsSummary.apiUnavailable}
+                        </div>
+                    </>
+                }
             >
-                {taskCountsSummary.total}
-            </WfoHeaderBadge>
-        </EuiToolTip>
-    );
+                <WfoHeaderBadge
+                    color={theme.colors.emptyShade}
+                    textColor={theme.colors.shadow}
+                    iconType={() => (
+                        <WfoXCircleFill color={theme.colors.danger} />
+                    )}
+                >
+                    {taskCountsSummary.total}
+                </WfoHeaderBadge>
+            </EuiToolTip>
+        );
+    } else {
+        return (
+            <EuiToolTip
+                position="bottom"
+                content={
+                    <>
+                        <div>No failed tasks!</div>
+                    </>
+                }
+            >
+                <WfoHeaderBadge
+                    color={theme.colors.emptyShade}
+                    textColor={theme.colors.shadow}
+                    iconType={() => (
+                        <WfoCheckmarkCircleFill color={theme.colors.success} />
+                    )}
+                >
+                    {taskCountsSummary.total}
+                </WfoHeaderBadge>
+            </EuiToolTip>
+        );
+    }
 };

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
@@ -8,6 +8,7 @@ import {
     useProcessStatusCountsQuery,
 } from '../../../hooks/useProcessStatusCountsQuery';
 import { WfoCheckmarkCircleFill } from '../../../icons';
+import { useTranslations } from 'next-intl';
 
 type TaskCountsSummary = {
     failed: number;
@@ -33,36 +34,11 @@ const getTaskCountsSummary = (
 };
 
 export const WfoFailedTasksBadge = () => {
+    const t = useTranslations('common');
     const { theme } = useOrchestratorTheme();
     const { data: processStatusCounts } = useProcessStatusCountsQuery();
     const taskCountsSummary = getTaskCountsSummary(processStatusCounts);
 
-    // <<<<<<< HEAD:packages/orchestrator-ui-components/src/components/WfoBadges/WfoFailedTasksBadge/WfoFailedTasksBadge.tsx
-    //     return (
-    //         <EuiToolTip
-    //             position="bottom"
-    //             content={
-    //                 <>
-    //                     <div>Failed: {taskCountsSummary.failed}</div>
-    //                     <div>
-    //                         Inconsistent data: {taskCountsSummary.inconsistentData}
-    //                     </div>
-    //                     <div>
-    //                         API unavailable: {taskCountsSummary.apiUnavailable}
-    //                     </div>
-    //                 </>
-    //             }
-    //         >
-    //             <WfoHeaderBadge
-    //                 color={theme.colors.emptyShade}
-    //                 textColor={theme.colors.shadow}
-    //                 iconType={() => <WfoXCircleFill color={theme.colors.danger} />}
-    //             >
-    //                 {taskCountsSummary.total}
-    //             </WfoHeaderBadge>
-    //         </EuiToolTip>
-    //     );
-    // =======
     if (taskCountsSummary.total != 0) {
         return (
             <EuiToolTip
@@ -97,7 +73,7 @@ export const WfoFailedTasksBadge = () => {
                 position="bottom"
                 content={
                     <>
-                        <div>No failed tasks!</div>
+                        <div>{t('noFailedTasks')}</div>
                     </>
                 }
             >

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -10,8 +10,8 @@
         "close": "Close",
         "newSubscription": "New subscription",
         "newTask": "New task",
-        "search": "Search",
-        "noFailedTasks": "No failed tasks!"
+        "noFailedTasks": "No failed tasks!",
+        "search": "Search"
     },
     "workflow": {
         "start_workflow_title": "Start workflow"

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -10,7 +10,8 @@
         "close": "Close",
         "newSubscription": "New subscription",
         "newTask": "New task",
-        "search": "Search"
+        "search": "Search",
+        "noFailedTasks": "No failed tasks!"
     },
     "workflow": {
         "start_workflow_title": "Start workflow"

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -10,8 +10,8 @@
         "close": "Sluiten",
         "newSubscription": "Nieuwe subscription",
         "newTask": "Nieuwe taak",
-        "search": "Zoeken",
-        "noFailedTasks": "Geen gefaalde taken!"
+        "noFailedTasks": "Geen gefaalde taken!",
+        "search": "Zoeken"
     },
     "workflow": {
         "start_workflow_title": "Start workflow"

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -10,7 +10,8 @@
         "close": "Sluiten",
         "newSubscription": "Nieuwe subscription",
         "newTask": "Nieuwe taak",
-        "search": "Zoeken"
+        "search": "Zoeken",
+        "noFailedTasks": "Geen gefaalde taken!"
     },
     "workflow": {
         "start_workflow_title": "Start workflow"


### PR DESCRIPTION
* Fixes the failed task banner icon to green (success) when no failed tasks are found
* Fixes the engineer banner icon to red (danger), when the engine is not running, but pausing or paused