### PR TITLE
318 - Hides the collapseAll button when the raw json is visible

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WFOWorkflowSteps/WFOWorkflowStepList/WFOStepListHeader.tsx
+++ b/packages/orchestrator-ui-components/src/components/WFOWorkflowSteps/WFOWorkflowStepList/WFOStepListHeader.tsx
@@ -64,12 +64,14 @@ export const WFOStepListHeader: FC<WFOStepListHeaderProps> = ({
                 <EuiText css={stepListContentBoldTextStyle}>
                     {t('steps')}
                 </EuiText>
-                <EuiText
-                    css={stepListContentAnchorStyle}
-                    onClick={onToggleAllDetailsIsOpen}
-                >
-                    {allDetailToggleText}
-                </EuiText>
+                {!showRaw && (
+                    <EuiText
+                        css={stepListContentAnchorStyle}
+                        onClick={onToggleAllDetailsIsOpen}
+                    >
+                        {allDetailToggleText}
+                    </EuiText>
+                )}
             </EuiFlexGroup>
 
             {/* Right side: view options */}


### PR DESCRIPTION
#318 

Hides the collapseAll button when the raw json is visible
![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/5e26d281-f81b-43f8-98bf-ef349fd64d38)
