### PR TITLE
add PB column to RT metadata table

### DIFF
--- a/packages/orchestrator-ui-components/src/graphqlQueries/resourceTypesQuery.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/resourceTypesQuery.ts
@@ -22,6 +22,14 @@ export const GET_RESOURCE_TYPES_GRAPHQL_QUERY: TypedDocumentNode<
                 resourceTypeId
                 resourceType
                 description
+                productBlocks {
+                    description
+                    name
+                    productBlockId
+                    status
+                    createdAt
+                    endDate
+                }
             }
             pageInfo {
                 endCursor

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -62,7 +62,8 @@
         "resourceTypes": {
             "type": "Resource type",
             "description": "Resource type description",
-            "resourceId": "Resource Id"
+            "resourceId": "Resource Id",
+            "usedInProductBlocks": "Used in product blocks"
         },
         "workflows": {
             "name": "Workflow",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -62,7 +62,8 @@
         "resourceTypes": {
             "type": "Resource type",
             "description": "Resource type beschrijving",
-            "resourceId": "Resource Id"
+            "resourceId": "Resource Id",
+            "usedInProductBlocks": "Gebruikt in product blocks"
         },
         "workflows": {
             "name": "Workflow",

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoResourceTypesPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../hooks';
 
 import { GET_RESOURCE_TYPES_GRAPHQL_QUERY } from '../../graphqlQueries';
-
+import { EuiBadgeGroup } from '@elastic/eui';
 import { WfoMetadataPageLayout } from './WfoMetadataPageLayout';
 import { WfoFirstPartUUID } from '../../components/WfoTable/WfoFirstPartUUID';
 import { mapSortableAndFilterableValuesToTableColumnConfig } from '../../components/WfoTable/utils/mapSortableAndFilterableValuesToTableColumnConfig';
@@ -38,6 +38,8 @@ export const RESOURCE_TYPE_FIELD_TYPE: keyof ResourceTypeDefinition =
     'resourceType';
 export const RESOURCE_TYPE_FIELD_DESCRIPTION: keyof ResourceTypeDefinition =
     'description';
+export const RESOURCE_TYPE_FIELD_PRODUCT_BLOCKS: keyof ResourceTypeDefinition =
+    'productBlocks';
 
 export const WfoResourceTypesPage = () => {
     const t = useTranslations('metadata.resourceTypes');
@@ -91,7 +93,34 @@ export const WfoResourceTypesPage = () => {
         description: {
             field: RESOURCE_TYPE_FIELD_DESCRIPTION,
             name: t('description'),
-            width: '400',
+        },
+        productBlocks: {
+            field: RESOURCE_TYPE_FIELD_PRODUCT_BLOCKS,
+            name: t('usedInProductBlocks'),
+            render: (productBlocks) => (
+                <>
+                    {productBlocks.map((productBlock, index) => (
+                        <WfoProductBlockBadge
+                            key={index}
+                            badgeType={BadgeType.PRODUCT_BLOCK}
+                        >
+                            {productBlock.name}
+                        </WfoProductBlockBadge>
+                    ))}
+                </>
+            ),
+            renderDetails: (productBlocks) => (
+                <EuiBadgeGroup gutterSize="s">
+                    {productBlocks.map((productBlock, index) => (
+                        <WfoProductBlockBadge
+                            key={index}
+                            badgeType={BadgeType.PRODUCT_BLOCK}
+                        >
+                            {productBlock.name}
+                        </WfoProductBlockBadge>
+                    ))}
+                </EuiBadgeGroup>
+            ),
         },
     };
 

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -43,6 +43,7 @@ export interface ResourceTypeDefinition {
     description: string;
     resourceType: string;
     resourceTypeId: string;
+    productBlocks: ProductBlockDefinition[];
 }
 
 export interface ProductBlockDefinition {


### PR DESCRIPTION
added `used in product blocks` column to Resource type table

<img width="1648" alt="image" src="https://github.com/workfloworchestrator/orchestrator-ui/assets/83226590/aacb921a-cd66-4aec-987d-e0c44ce72662">
