### PR TITLE
Honor tree order and started working on hiding keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-    - package-ecosystem: "npm" # See documentation for possible values
-      directory: "/" # Location of package manifests
+    - package-ecosystem: 'npm' # See documentation for possible values
+      directory: '/' # Location of package manifests
       schedule:
-          interval: "weekly"
+          interval: 'weekly'

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -59,16 +59,16 @@ jobs:
         runs-on: ubuntu-latest
         needs: cache-dependencies
         steps:
-            -   uses: actions/checkout@v3
-            -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v3
-                with:
-                    node-version: ${{ matrix.node-version }}
-                    cache: 'yarn'
-            -   uses: actions/cache@v2
-                with:
-                    path: '**/node_modules'
-                    key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/package.json') }}
-            -   name: Installing dependencies
-                run: yarn install --frozen-lockfile
-            -   run: yarn run build
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: 'yarn'
+            - uses: actions/cache@v2
+              with:
+                  path: '**/node_modules'
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/package.json') }}
+            - name: Installing dependencies
+              run: yarn install --frozen-lockfile
+            - run: yarn run build

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -3,7 +3,7 @@ on:
     workflow_dispatch:
     push:
         branches:
-            - "main"
+            - 'main'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -23,11 +23,11 @@ jobs:
                   key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/package.json') }}
             - name: Create .npmrc file with the NPM token
               run: |
-                cat << EOF > "$HOME/.npmrc"
-                  //registry.npmjs.org/:_authToken=$NPM_TOKEN
-                EOF
+                  cat << EOF > "$HOME/.npmrc"
+                    //registry.npmjs.org/:_authToken=$NPM_TOKEN
+                  EOF
               env:
-                NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Installing dependencies
               run: yarn install --frozen-lockfile
             - name: Create Release Pull Request or Publish

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscription.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscription.tsx
@@ -26,8 +26,7 @@ type WfoSubscriptionProps = {
 export const WfoSubscription = ({ subscriptionId }: WfoSubscriptionProps) => {
     const t = useTranslations('subscriptions.detail');
     const [selectedTabId, setSelectedTabId] = useState<SubscriptionTabIds>(
-        // SubscriptionTabIds.GENERAL_TAB,
-        SubscriptionTabIds.SERVICE_CONFIGURATION_TAB,
+        SubscriptionTabIds.GENERAL_TAB,
     );
 
     const { data, isFetching } = useQueryWithGraphql(

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscription.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscription.tsx
@@ -26,7 +26,8 @@ type WfoSubscriptionProps = {
 export const WfoSubscription = ({ subscriptionId }: WfoSubscriptionProps) => {
     const t = useTranslations('subscriptions.detail');
     const [selectedTabId, setSelectedTabId] = useState<SubscriptionTabIds>(
-        SubscriptionTabIds.GENERAL_TAB,
+        // SubscriptionTabIds.GENERAL_TAB,
+        SubscriptionTabIds.SERVICE_CONFIGURATION_TAB,
     );
 
     const { data, isFetching } = useQueryWithGraphql(
@@ -52,7 +53,6 @@ export const WfoSubscription = ({ subscriptionId }: WfoSubscriptionProps) => {
             </EuiTab>
         ));
 
-    // Todo #97: Find out if pre fetch can be used again. The shape of table cache seems to have changed
     const subscriptionResult =
         data && data.subscriptions && data.subscriptions.page;
     const subscriptionDetail = subscriptionResult

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
@@ -147,6 +147,7 @@ export const WfoSubscriptionDetailTree = ({
                                     productBlockInstanceValues={
                                         block.productBlockInstanceValues
                                     }
+                                    inUseByRelations={block.inUseByRelations}
                                     id={id}
                                 />
                             );

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
@@ -133,13 +133,17 @@ export const WfoSubscriptionDetailTree = ({
                     )}
                     {selectedIds.length !== 0 &&
                         selectedIds.map((id, index) => {
+                            const block =
+                                productBlockInstances[selectedIds[index]];
                             return (
                                 <WfoSubscriptionProductBlock
                                     key={index}
+                                    o
+                                    subscriptionInstanceId={
+                                        block.subscriptionInstanceId
+                                    }
                                     productBlockInstanceValues={
-                                        productBlockInstances[
-                                            selectedIds[index]
-                                        ].productBlockInstanceValues
+                                        block.productBlockInstanceValues
                                     }
                                     id={id}
                                 />

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
@@ -138,7 +138,9 @@ export const WfoSubscriptionDetailTree = ({
                             return (
                                 <WfoSubscriptionProductBlock
                                     key={index}
-                                    o
+                                    ownerSubscriptionId={
+                                        block.ownerSubscriptionId
+                                    }
                                     subscriptionInstanceId={
                                         block.subscriptionInstanceId
                                     }

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionDetailTree.tsx
@@ -80,7 +80,7 @@ export const WfoSubscriptionDetailTree = ({
             }
         }
 
-        // Add an entry for this node to the map so that any future children can lookup the parent
+        // Add an entry for this node to the map so that any future children can look up the parent
         idToNodeMap[shallowCopy.id] = shallowCopy;
     });
 
@@ -132,7 +132,7 @@ export const WfoSubscriptionDetailTree = ({
                         </EuiCallOut>
                     )}
                     {selectedIds.length !== 0 &&
-                        selectedIds.reverse().map((id, index) => {
+                        selectedIds.map((id, index) => {
                             return (
                                 <WfoSubscriptionProductBlock
                                     key={index}

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
@@ -82,7 +82,9 @@ export const WfoSubscriptionProductBlock = ({
                                 )}
                             </h3>
                         </EuiText>
-                        <EuiText>Instance ID: {subscriptionInstanceId}</EuiText>
+                        <EuiText>{`${t(
+                            'subscriptionInstanceId',
+                        )}: ${subscriptionInstanceId}`}</EuiText>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                         <EuiButtonEmpty

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
@@ -11,8 +11,12 @@ import {
 } from '@elastic/eui';
 import { FieldValue } from '../../types';
 import { getProductBlockTitle } from './utils';
+import { useOrchestratorTheme, useWithOrchestratorTheme } from '../../hooks';
+import { getStyles } from './styles';
 
 interface WfoSubscriptionProductBlockProps {
+    ownerSubscriptionId: string;
+    subscriptionInstanceId: string;
     productBlockInstanceValues: FieldValue[];
     id: number;
 }
@@ -24,18 +28,27 @@ export const HIDDEN_KEYS = [
     // 'owner_subscription_id',
 ];
 export const WfoSubscriptionProductBlock = ({
+    ownerSubscriptionId,
+    subscriptionInstanceId,
     productBlockInstanceValues,
 }: WfoSubscriptionProductBlockProps) => {
+    const { productBlockPanelStyle } = useWithOrchestratorTheme(getStyles);
+
     const [showAllKeys, setShowAllKeys] = useState(false);
 
     const isLastCell = (index: number): number => {
         return index === productBlockInstanceValues.length - 1 ? 0 : 1;
     };
+    console.log(productBlockInstanceValues);
 
     return (
         <>
             <EuiSpacer size={'m'}></EuiSpacer>
-            <EuiPanel>
+            <EuiPanel
+                color="transparent"
+                hasShadow={false}
+                css={productBlockPanelStyle}
+            >
                 <div style={{ marginTop: 5 }}>
                     <EuiFlexGroup justifyContent="spaceBetween">
                         <EuiFlexItem>
@@ -45,6 +58,9 @@ export const WfoSubscriptionProductBlock = ({
                                         productBlockInstanceValues,
                                     )}
                                 </h3>
+                            </EuiText>
+                            <EuiText>
+                                Instance ID: {subscriptionInstanceId}
                             </EuiText>
                         </EuiFlexItem>
                         <EuiFlexItem grow={false}>
@@ -61,11 +77,8 @@ export const WfoSubscriptionProductBlock = ({
                     {
                         <table
                             width="100%"
-                            bgcolor={'#F1F5F9'}
-                            style={{
-                                borderCollapse: 'separate',
-                                borderRadius: 8,
-                            }}
+                            // bgcolor={theme.colors.lightestShade}
+                            // style={tableStyle}
                         >
                             {productBlockInstanceValues
                                 .filter(

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiAccordion } from '@elastic/eui';
 
 import {
@@ -9,7 +9,6 @@ import {
     EuiSpacer,
     EuiText,
 } from '@elastic/eui';
-import { TreeContext, TreeContextType } from '../../contexts';
 import { FieldValue } from '../../types';
 import { getProductBlockTitle } from './utils';
 
@@ -18,13 +17,16 @@ interface WfoSubscriptionProductBlockProps {
     id: number;
 }
 
+export const ALWAYS_HIDDEN_KEYS = ['title', 'name', 'label'];
+export const HIDDEN_KEYS = [
+    'name', // Todo: remove this, it's only here to test
+    // 'subscription_instance_id',
+    // 'owner_subscription_id',
+];
 export const WfoSubscriptionProductBlock = ({
     productBlockInstanceValues,
-    id,
 }: WfoSubscriptionProductBlockProps) => {
-    const { toggleSelectedId } = React.useContext(
-        TreeContext,
-    ) as TreeContextType;
+    const [showAllKeys, setShowAllKeys] = useState(false);
 
     const isLastCell = (index: number): number => {
         return index === productBlockInstanceValues.length - 1 ? 0 : 1;
@@ -50,7 +52,7 @@ export const WfoSubscriptionProductBlock = ({
                                 aria-label="Close"
                                 size={'m'}
                                 iconType={'cross'}
-                                onClick={() => toggleSelectedId(id)}
+                                onClick={() => setShowAllKeys(!showAllKeys)}
                             />
                         </EuiFlexItem>
                     </EuiFlexGroup>
@@ -65,8 +67,14 @@ export const WfoSubscriptionProductBlock = ({
                                 borderRadius: 8,
                             }}
                         >
-                            {productBlockInstanceValues.map(
-                                (productBlockInstanceValue, index) =>
+                            {productBlockInstanceValues
+                                .filter(
+                                    (productBlockInstanceValue) =>
+                                        !HIDDEN_KEYS.includes(
+                                            productBlockInstanceValue.field,
+                                        ) || showAllKeys,
+                                )
+                                .map((productBlockInstanceValue, index) =>
                                     !productBlockInstanceValue.field.startsWith(
                                         'ims_ci',
                                     ) ? (
@@ -141,7 +149,7 @@ export const WfoSubscriptionProductBlock = ({
                                             </td>
                                         </tr>
                                     ),
-                            )}
+                                )}
                         </table>
                     }
                 </div>

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { EuiAccordion } from '@elastic/eui';
 
 import {
-    EuiButtonIcon,
+    EuiButtonEmpty,
+    EuiIcon,
     EuiFlexGroup,
     EuiFlexItem,
     EuiPanel,
@@ -13,6 +13,8 @@ import { FieldValue } from '../../types';
 import { getProductBlockTitle } from './utils';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '../../hooks';
 import { getStyles } from './styles';
+import { camelToHuman } from '../../utils';
+import { useTranslations } from 'next-intl';
 
 interface WfoSubscriptionProductBlockProps {
     ownerSubscriptionId: string;
@@ -21,25 +23,23 @@ interface WfoSubscriptionProductBlockProps {
     id: number;
 }
 
-export const ALWAYS_HIDDEN_KEYS = ['title', 'name', 'label'];
-export const HIDDEN_KEYS = [
-    'name', // Todo: remove this, it's only here to test
-    // 'subscription_instance_id',
-    // 'owner_subscription_id',
-];
+export const HIDDEN_KEYS = ['title', 'name', 'label'];
+
 export const WfoSubscriptionProductBlock = ({
     ownerSubscriptionId,
     subscriptionInstanceId,
     productBlockInstanceValues,
 }: WfoSubscriptionProductBlockProps) => {
+    const t = useTranslations('subscriptions.detail');
+    const { theme } = useOrchestratorTheme();
     const { productBlockPanelStyle } = useWithOrchestratorTheme(getStyles);
 
-    const [showAllKeys, setShowAllKeys] = useState(false);
+    const [hideDetails, setHideDetails] = useState(true);
 
-    const isLastCell = (index: number): number => {
-        return index === productBlockInstanceValues.length - 1 ? 0 : 1;
+    const getBorderThickness = (index: number): number => {
+        if (!hideDetails) return 0;
+        return index === 0 ? 1 : 0;
     };
-    console.log(productBlockInstanceValues);
 
     return (
         <>
@@ -49,123 +49,126 @@ export const WfoSubscriptionProductBlock = ({
                 hasShadow={false}
                 css={productBlockPanelStyle}
             >
-                <div style={{ marginTop: 5 }}>
-                    <EuiFlexGroup justifyContent="spaceBetween">
-                        <EuiFlexItem>
-                            <EuiText grow={false}>
-                                <h3>
-                                    {getProductBlockTitle(
-                                        productBlockInstanceValues,
-                                    )}
-                                </h3>
-                            </EuiText>
-                            <EuiText>
-                                Instance ID: {subscriptionInstanceId}
-                            </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                            <EuiButtonIcon
-                                aria-label="Close"
-                                size={'m'}
-                                iconType={'cross'}
-                                onClick={() => setShowAllKeys(!showAllKeys)}
-                            />
-                        </EuiFlexItem>
-                    </EuiFlexGroup>
-
-                    <EuiSpacer size={'xs'}></EuiSpacer>
-                    {
-                        <table
-                            width="100%"
-                            // bgcolor={theme.colors.lightestShade}
-                            // style={tableStyle}
+                <EuiFlexGroup>
+                    <EuiFlexItem grow={false}>
+                        <div
+                            style={{
+                                width: 45,
+                                height: 45,
+                                backgroundColor: 'rgb(193,221,241,1)',
+                                paddingTop: 13,
+                                paddingLeft: 15,
+                                borderRadius: 7,
+                            }}
                         >
-                            {productBlockInstanceValues
-                                .filter(
-                                    (productBlockInstanceValue) =>
-                                        !HIDDEN_KEYS.includes(
-                                            productBlockInstanceValue.field,
-                                        ) || showAllKeys,
-                                )
-                                .map((productBlockInstanceValue, index) =>
-                                    !productBlockInstanceValue.field.startsWith(
-                                        'ims_ci',
-                                    ) ? (
-                                        <tr key={index}>
-                                            <td
-                                                valign={'top'}
-                                                style={{
-                                                    width: 250,
-                                                    padding: 10,
-                                                    borderBottom: `solid ${isLastCell(
-                                                        index,
-                                                    )}px #ddd`,
-                                                }}
-                                            >
-                                                <b>
-                                                    {
-                                                        productBlockInstanceValue.field
-                                                    }
-                                                </b>
-                                            </td>
-                                            <td
-                                                style={{
-                                                    padding: 10,
-                                                    borderBottom: `solid ${isLastCell(
-                                                        index,
-                                                    )}px #ddd`,
-                                                }}
-                                            >
-                                                {
-                                                    productBlockInstanceValue.value
-                                                }
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        <tr key={index}>
-                                            <td
-                                                colSpan={3}
-                                                style={{
-                                                    padding: 10,
-                                                    borderBottom: `solid ${isLastCell(
-                                                        index,
-                                                    )}px #ddd`,
-                                                }}
-                                            >
-                                                <EuiAccordion
-                                                    id={
-                                                        productBlockInstanceValue.field
-                                                    }
-                                                    arrowDisplay="left"
-                                                    buttonContent={
-                                                        <div>
-                                                            <td
-                                                                valign={'top'}
-                                                                style={{
-                                                                    width: 222,
-                                                                }}
-                                                            >
-                                                                <b>
-                                                                    {
-                                                                        productBlockInstanceValue.field
-                                                                    }
-                                                                </b>
-                                                            </td>
-                                                            <td>
-                                                                {
-                                                                    productBlockInstanceValue.value
-                                                                }
-                                                            </td>
-                                                        </div>
-                                                    }
-                                                ></EuiAccordion>
-                                            </td>
-                                        </tr>
-                                    ),
+                            <EuiIcon
+                                type="filebeatApp"
+                                color={theme.colors.primary}
+                            />
+                        </div>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                        <EuiText grow={true}>
+                            <h3>
+                                {getProductBlockTitle(
+                                    productBlockInstanceValues,
                                 )}
-                        </table>
-                    }
-                </div>
+                            </h3>
+                        </EuiText>
+                        <EuiText>Instance ID: {subscriptionInstanceId}</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                        <EuiButtonEmpty
+                            aria-label={
+                                hideDetails
+                                    ? t('showDetails')
+                                    : t('hideDetails')
+                            }
+                            size={'m'}
+                            onClick={() => setHideDetails(!hideDetails)}
+                        >
+                            {hideDetails ? t('showDetails') : t('hideDetails')}
+                        </EuiButtonEmpty>
+                    </EuiFlexItem>
+                </EuiFlexGroup>
+
+                <EuiSpacer size={'m'}></EuiSpacer>
+                {
+                    <table width="100%">
+                        {!hideDetails && (
+                            <tr key={-1}>
+                                <td
+                                    valign={'top'}
+                                    style={{
+                                        width: 250,
+                                        paddingLeft: 0,
+                                        paddingTop: 10,
+                                        paddingBottom: 10,
+                                        borderTop: `solid 1px #ddd`,
+                                        borderBottom: `solid 1px #ddd`,
+                                    }}
+                                >
+                                    <b>Owner subscription ID</b>
+                                </td>
+                                <td
+                                    style={{
+                                        paddingLeft: 0,
+                                        paddingTop: 10,
+                                        paddingBottom: 10,
+                                        borderTop: `solid 1px #ddd`,
+                                        borderBottom: `solid 1px #ddd`,
+                                    }}
+                                >
+                                    {ownerSubscriptionId}
+                                </td>
+                            </tr>
+                        )}
+
+                        {productBlockInstanceValues
+                            .filter(
+                                (productBlockInstanceValue) =>
+                                    !HIDDEN_KEYS.includes(
+                                        productBlockInstanceValue.field,
+                                    ),
+                            )
+                            .map((productBlockInstanceValue, index) => (
+                                <tr key={index}>
+                                    <td
+                                        valign={'top'}
+                                        style={{
+                                            width: 250,
+                                            paddingLeft: 0,
+                                            paddingTop: 10,
+                                            paddingBottom: 10,
+                                            borderTop: `solid ${getBorderThickness(
+                                                index,
+                                            )}px #ddd`,
+                                            borderBottom: `solid 1px #ddd`,
+                                        }}
+                                    >
+                                        <b>
+                                            {camelToHuman(
+                                                productBlockInstanceValue.field,
+                                            )}
+                                        </b>
+                                    </td>
+                                    <td
+                                        style={{
+                                            paddingLeft: 0,
+                                            paddingTop: 10,
+                                            paddingBottom: 10,
+                                            borderTop: `solid ${getBorderThickness(
+                                                index,
+                                            )}px #ddd`,
+                                            borderBottom: `solid 1px #ddd`,
+                                        }}
+                                    >
+                                        {productBlockInstanceValue.value}
+                                    </td>
+                                </tr>
+                            ))}
+                    </table>
+                }
             </EuiPanel>
         </>
     );

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionProductBlock.tsx
@@ -8,18 +8,23 @@ import {
     EuiPanel,
     EuiSpacer,
     EuiText,
+    EuiBadge,
+    EuiCodeBlock,
 } from '@elastic/eui';
-import { FieldValue } from '../../types';
+import { FieldValue, InUseByRelation } from '../../types';
 import { getProductBlockTitle } from './utils';
 import { useOrchestratorTheme, useWithOrchestratorTheme } from '../../hooks';
 import { getStyles } from './styles';
 import { camelToHuman } from '../../utils';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
+import { PATH_SUBSCRIPTIONS } from '../WfoPageTemplate';
 
 interface WfoSubscriptionProductBlockProps {
     ownerSubscriptionId: string;
     subscriptionInstanceId: string;
     productBlockInstanceValues: FieldValue[];
+    inUseByRelations: InUseByRelation[];
     id: number;
 }
 
@@ -29,16 +34,27 @@ export const WfoSubscriptionProductBlock = ({
     ownerSubscriptionId,
     subscriptionInstanceId,
     productBlockInstanceValues,
+    inUseByRelations,
 }: WfoSubscriptionProductBlockProps) => {
+    const router = useRouter();
+    const subscriptionId = router.query['subscriptionId'];
+
     const t = useTranslations('subscriptions.detail');
     const { theme } = useOrchestratorTheme();
-    const { productBlockPanelStyle } = useWithOrchestratorTheme(getStyles);
+    const {
+        productBlockIconStyle,
+        productBlockPanelStyle,
+        productBlockLeftColStyle,
+        productBlockFirstLeftColStyle,
+        productBlockRightColStyle,
+        productBlockFirstRightColStyle,
+    } = useWithOrchestratorTheme(getStyles);
 
     const [hideDetails, setHideDetails] = useState(true);
 
-    const getBorderThickness = (index: number): number => {
-        if (!hideDetails) return 0;
-        return index === 0 ? 1 : 0;
+    const isFirstBlock = (index: number): boolean => {
+        if (!hideDetails) return false;
+        return index === 0;
     };
 
     return (
@@ -51,16 +67,7 @@ export const WfoSubscriptionProductBlock = ({
             >
                 <EuiFlexGroup>
                     <EuiFlexItem grow={false}>
-                        <div
-                            style={{
-                                width: 45,
-                                height: 45,
-                                backgroundColor: 'rgb(193,221,241,1)',
-                                paddingTop: 13,
-                                paddingLeft: 15,
-                                borderRadius: 7,
-                            }}
-                        >
+                        <div css={productBlockIconStyle}>
                             <EuiIcon
                                 type="filebeatApp"
                                 color={theme.colors.primary}
@@ -96,32 +103,54 @@ export const WfoSubscriptionProductBlock = ({
                 {
                     <table width="100%">
                         {!hideDetails && (
-                            <tr key={-1}>
-                                <td
-                                    valign={'top'}
-                                    style={{
-                                        width: 250,
-                                        paddingLeft: 0,
-                                        paddingTop: 10,
-                                        paddingBottom: 10,
-                                        borderTop: `solid 1px #ddd`,
-                                        borderBottom: `solid 1px #ddd`,
-                                    }}
-                                >
-                                    <b>Owner subscription ID</b>
-                                </td>
-                                <td
-                                    style={{
-                                        paddingLeft: 0,
-                                        paddingTop: 10,
-                                        paddingBottom: 10,
-                                        borderTop: `solid 1px #ddd`,
-                                        borderBottom: `solid 1px #ddd`,
-                                    }}
-                                >
-                                    {ownerSubscriptionId}
-                                </td>
-                            </tr>
+                            <>
+                                <tr key={-2}>
+                                    <td
+                                        valign={'top'}
+                                        css={productBlockFirstLeftColStyle}
+                                    >
+                                        <b>{t('ownerSubscriptionId')}</b>
+                                    </td>
+                                    <td
+                                        valign={'top'}
+                                        css={productBlockFirstRightColStyle}
+                                    >
+                                        {subscriptionId ===
+                                        ownerSubscriptionId ? (
+                                            <>
+                                                {subscriptionId}
+                                                <EuiBadge>{t('self')}</EuiBadge>
+                                            </>
+                                        ) : (
+                                            <a
+                                                href={`${PATH_SUBSCRIPTIONS}/${ownerSubscriptionId}`}
+                                            >
+                                                {ownerSubscriptionId}
+                                            </a>
+                                        )}
+                                    </td>
+                                </tr>
+                                <tr key={-1}>
+                                    <td
+                                        valign={'top'}
+                                        css={productBlockLeftColStyle}
+                                    >
+                                        <b>{t('inUseByRelations')}</b>
+                                    </td>
+                                    <td
+                                        valign={'top'}
+                                        css={productBlockRightColStyle}
+                                    >
+                                        <EuiCodeBlock language="json">
+                                            {JSON.stringify(
+                                                inUseByRelations,
+                                                null,
+                                                4,
+                                            )}
+                                        </EuiCodeBlock>
+                                    </td>
+                                </tr>
+                            </>
                         )}
 
                         {productBlockInstanceValues
@@ -135,16 +164,11 @@ export const WfoSubscriptionProductBlock = ({
                                 <tr key={index}>
                                     <td
                                         valign={'top'}
-                                        style={{
-                                            width: 250,
-                                            paddingLeft: 0,
-                                            paddingTop: 10,
-                                            paddingBottom: 10,
-                                            borderTop: `solid ${getBorderThickness(
-                                                index,
-                                            )}px #ddd`,
-                                            borderBottom: `solid 1px #ddd`,
-                                        }}
+                                        css={
+                                            isFirstBlock(index)
+                                                ? productBlockFirstLeftColStyle
+                                                : productBlockLeftColStyle
+                                        }
                                     >
                                         <b>
                                             {camelToHuman(
@@ -153,17 +177,21 @@ export const WfoSubscriptionProductBlock = ({
                                         </b>
                                     </td>
                                     <td
-                                        style={{
-                                            paddingLeft: 0,
-                                            paddingTop: 10,
-                                            paddingBottom: 10,
-                                            borderTop: `solid ${getBorderThickness(
-                                                index,
-                                            )}px #ddd`,
-                                            borderBottom: `solid 1px #ddd`,
-                                        }}
+                                        valign={'top'}
+                                        css={
+                                            isFirstBlock(index)
+                                                ? productBlockFirstRightColStyle
+                                                : productBlockRightColStyle
+                                        }
                                     >
-                                        {productBlockInstanceValue.value}
+                                        {typeof productBlockInstanceValue.value ===
+                                        'boolean' ? (
+                                            <EuiBadge>
+                                                {productBlockInstanceValue.value.toString()}
+                                            </EuiBadge>
+                                        ) : (
+                                            productBlockInstanceValue.value
+                                        )}
                                     </td>
                                 </tr>
                             ))}

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
@@ -39,13 +39,51 @@ export const getStyles = (theme: EuiThemeComputed) => {
     const lastHeaderCellStyle = css({
         padding: theme.base,
         paddingLeft: 0,
-        width: '250px',
+        width: 250,
         fontWeight: theme.font.weight.medium,
         border: 0,
     });
 
+    const productBlockIconStyle = css({
+        width: 45,
+        height: 45,
+        backgroundColor: 'rgb(193,221,241,1)',
+        paddingTop: 13,
+        paddingLeft: 15,
+        borderRadius: 7,
+    });
+
     const productBlockPanelStyle = css({
         backgroundColor: theme.colors.lightestShade,
+    });
+
+    const productBlockLeftCol = {
+        width: 250,
+        paddingLeft: 0,
+        paddingTop: 10,
+        paddingBottom: 10,
+        borderBottom: `solid 1px ${theme.colors.lightShade}`,
+    };
+
+    const productBlockLeftColStyle = css({ ...productBlockLeftCol });
+
+    const productBlockFirstLeftColStyle = css({
+        borderTop: `solid 1px ${theme.colors.lightShade}`,
+        ...productBlockLeftCol,
+    });
+
+    const productBlockRightCol = {
+        paddingLeft: 0,
+        paddingTop: 10,
+        paddingBottom: 10,
+        borderBottom: `solid 1px ${theme.colors.lightShade}`,
+    };
+
+    const productBlockRightColStyle = css({ ...productBlockRightCol });
+
+    const productBlockFirstRightColStyle = css({
+        borderTop: `solid 1px ${theme.colors.lightShade}`,
+        ...productBlockRightCol,
     });
 
     return {
@@ -57,6 +95,11 @@ export const getStyles = (theme: EuiThemeComputed) => {
         emptyCellStyle,
         lastContentCellStyle,
         lastHeaderCellStyle,
+        productBlockIconStyle,
         productBlockPanelStyle,
+        productBlockLeftColStyle,
+        productBlockFirstLeftColStyle,
+        productBlockRightColStyle,
+        productBlockFirstRightColStyle,
     };
 };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/styles.ts
@@ -44,6 +44,10 @@ export const getStyles = (theme: EuiThemeComputed) => {
         border: 0,
     });
 
+    const productBlockPanelStyle = css({
+        backgroundColor: theme.colors.lightestShade,
+    });
+
     return {
         contentCellStyle,
         headerCellStyle,
@@ -53,5 +57,6 @@ export const getStyles = (theme: EuiThemeComputed) => {
         emptyCellStyle,
         lastContentCellStyle,
         lastHeaderCellStyle,
+        productBlockPanelStyle,
     };
 };

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/utils/utils.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/utils/utils.tsx
@@ -41,7 +41,7 @@ export const tabs = [
 export const getFieldFromProductBlockInstanceValues = (
     instanceValues: FieldValue[],
     field: string,
-): string | number => {
+): string | number | boolean => {
     const nameValue = instanceValues.find(
         (instanceValue) => instanceValue.field === field,
     );
@@ -50,7 +50,7 @@ export const getFieldFromProductBlockInstanceValues = (
 
 export const getProductBlockTitle = (
     instanceValues: FieldValue[],
-): string | number => {
+): string | number | boolean => {
     const title = getFieldFromProductBlockInstanceValues(
         instanceValues,
         'title',

--- a/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
@@ -14,7 +14,7 @@ import { useOrchestratorTheme } from '../../hooks';
 type Item = {
     id: number;
     icon: string;
-    label: string | number;
+    label: string | number | boolean;
 };
 
 type WfoTreeNodeProps = {

--- a/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
@@ -69,7 +69,7 @@ export const WfoTreeNode: FC<WfoTreeNodeProps> = ({
                     {selected ? (
                         <EuiListGroupItem
                             onClick={() => toggleSelectedId(item.id)}
-                            label={item.label}
+                            label={`${item.id} ${item.label}`}
                             isActive={selected}
                             color={'primary'}
                             extraAction={{
@@ -84,7 +84,7 @@ export const WfoTreeNode: FC<WfoTreeNodeProps> = ({
                     ) : (
                         <EuiListGroupItem
                             onClick={() => toggleSelectedId(item.id)}
-                            label={item.label}
+                            label={`${item.id} ${item.label}`}
                             isActive={selected}
                         />
                     )}

--- a/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTree/WfoTreeNode.tsx
@@ -69,7 +69,7 @@ export const WfoTreeNode: FC<WfoTreeNodeProps> = ({
                     {selected ? (
                         <EuiListGroupItem
                             onClick={() => toggleSelectedId(item.id)}
-                            label={`${item.id} ${item.label}`}
+                            label={item.label}
                             isActive={selected}
                             color={'primary'}
                             extraAction={{
@@ -84,7 +84,7 @@ export const WfoTreeNode: FC<WfoTreeNodeProps> = ({
                     ) : (
                         <EuiListGroupItem
                             onClick={() => toggleSelectedId(item.id)}
-                            label={`${item.id} ${item.label}`}
+                            label={item.label}
                             isActive={selected}
                         />
                     )}

--- a/packages/orchestrator-ui-components/src/components/WfoTree/treeUtils.spec.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTree/treeUtils.spec.ts
@@ -6,6 +6,7 @@ describe('getWfoTreeNodeDepth', () => {
     const sampleTree: TreeBlock = {
         id: 1,
         ownerSubscriptionId: 'subscription-1',
+        subscriptionInstanceId: 'subscription-1',
         parent: null,
         icon: 'folder',
         label: 'Root',
@@ -15,6 +16,7 @@ describe('getWfoTreeNodeDepth', () => {
             {
                 id: 2,
                 ownerSubscriptionId: 'subscription-2',
+                subscriptionInstanceId: 'subscription-2',
                 parent: 1,
                 icon: 'file',
                 label: 'File 1',
@@ -25,6 +27,7 @@ describe('getWfoTreeNodeDepth', () => {
             {
                 id: 3,
                 ownerSubscriptionId: 'subscription-3',
+                subscriptionInstanceId: 'subscription-3',
                 parent: 1,
                 icon: 'file',
                 label: 'File 2',
@@ -34,6 +37,7 @@ describe('getWfoTreeNodeDepth', () => {
                     {
                         id: 4,
                         ownerSubscriptionId: 'subscription-4',
+                        subscriptionInstanceId: 'subscription-4',
                         parent: 3,
                         icon: 'file',
                         label: 'File 2.1',
@@ -75,6 +79,7 @@ describe('getWfoTreeNodeDepth', () => {
         const invalidNode = {
             id: 1,
             ownerSubscriptionId: 'subscription-1',
+            subscriptionInstanceId: 'subscription-1',
             parent: 99, // Parent ID that does not exist
             icon: 'file',
             label: 'Invalid Node',

--- a/packages/orchestrator-ui-components/src/components/WfoTree/treeUtils.spec.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTree/treeUtils.spec.ts
@@ -12,6 +12,7 @@ describe('getWfoTreeNodeDepth', () => {
         label: 'Root',
         callback: jest.fn(),
         productBlockInstanceValues: [field],
+        inUseByRelations: [],
         children: [
             {
                 id: 2,
@@ -22,6 +23,7 @@ describe('getWfoTreeNodeDepth', () => {
                 label: 'File 1',
                 callback: jest.fn(),
                 productBlockInstanceValues: [field],
+                inUseByRelations: [],
                 children: [],
             },
             {
@@ -33,6 +35,7 @@ describe('getWfoTreeNodeDepth', () => {
                 label: 'File 2',
                 callback: jest.fn(),
                 productBlockInstanceValues: [field],
+                inUseByRelations: [],
                 children: [
                     {
                         id: 4,
@@ -43,6 +46,7 @@ describe('getWfoTreeNodeDepth', () => {
                         label: 'File 2.1',
                         callback: jest.fn(),
                         productBlockInstanceValues: [field],
+                        inUseByRelations: [],
                         children: [],
                     },
                 ],
@@ -85,6 +89,7 @@ describe('getWfoTreeNodeDepth', () => {
             label: 'Invalid Node',
             callback: jest.fn(),
             productBlockInstanceValues: [field],
+            inUseByRelations: [],
             children: [],
         };
 

--- a/packages/orchestrator-ui-components/src/contexts/TreeContext.tsx
+++ b/packages/orchestrator-ui-components/src/contexts/TreeContext.tsx
@@ -27,31 +27,30 @@ export const TreeProvider: React.FC<TreeProviderProps> = ({ children }) => {
 
     const toggleSelectedId = (id: number) => {
         if (selectedIds.includes(id)) {
-            const newSelectedIds = selectedIds.filter(
-                (selectedId) => selectedId !== id,
+            setSelectedIds((prevSelectedIds) =>
+                prevSelectedIds
+                    .filter((selectedId) => selectedId !== id)
+                    .sort((a, b) => a - b),
             );
-            setSelectedIds(newSelectedIds);
         } else {
-            const newSelectedIds = [...selectedIds, id];
-            setSelectedIds(newSelectedIds);
+            setSelectedIds((prevSelectedIds) =>
+                [...prevSelectedIds, id].sort((a, b) => a - b),
+            );
         }
     };
 
     const toggleExpandedId = (id: number) => {
         if (expandedIds.includes(id)) {
-            const newExpandedIds = expandedIds.filter(
-                (expandedId) => expandedId !== id,
+            setExpandedIds((prevExpandedIds) =>
+                prevExpandedIds.filter((expandedId) => expandedId !== id),
             );
-            setExpandedIds(newExpandedIds);
         } else {
-            const newExpandedIds = [...expandedIds, id];
-            setExpandedIds(newExpandedIds);
+            setExpandedIds((prevExpandedIds) => [...prevExpandedIds, id]);
         }
     };
 
     const expandAll = () => {
-        const newExpandedIds = Array.from(Array(depths.length).keys());
-        setExpandedIds(newExpandedIds);
+        setExpandedIds(Array.from(Array(depths.length).keys()));
     };
 
     const collapseAll = () => {

--- a/packages/orchestrator-ui-components/src/graphqlQueries/subscriptionDetailQuery.ts
+++ b/packages/orchestrator-ui-components/src/graphqlQueries/subscriptionDetailQuery.ts
@@ -42,6 +42,7 @@ export const GET_SUBSCRIPTION_DETAIL_GRAPHQL_QUERY: TypedDocumentNode<
                     parent
                     productBlockInstanceValues
                     subscriptionInstanceId
+                    inUseByRelations
                 }
                 processes(sortBy: { field: "startedAt", order: ASC }) {
                     page {

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -189,6 +189,8 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "ownerSubscriptionId": "Owner subscription ID",
+            "inUseByRelations": "In use by relation",
             "showDetails": "Show details",
             "hideDetails": "Hide details",
             "subscriptionDetails": "Subscription details",

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -189,6 +189,7 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "subscriptionInstanceId": "Instance ID",
             "ownerSubscriptionId": "Owner subscription ID",
             "inUseByRelations": "In use by relation",
             "showDetails": "Show details",

--- a/packages/orchestrator-ui-components/src/messages/en-US.json
+++ b/packages/orchestrator-ui-components/src/messages/en-US.json
@@ -189,6 +189,8 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "showDetails": "Show details",
+            "hideDetails": "Hide details",
             "subscriptionDetails": "Subscription details",
             "productName": "Product name",
             "fixedInputs": "Fixed inputs",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -189,6 +189,8 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "showDetails": "Toon details",
+            "hideDetails": "Verberg details",
             "subscriptionDetails": "Subscription detail",
             "productName": "Produkt",
             "fixedInputs": "Fixed inputs",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -189,6 +189,8 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "ownerSubscriptionId": "Owner subscription ID",
+            "inUseByRelations": "In use by relation",
             "showDetails": "Toon details",
             "hideDetails": "Verberg details",
             "subscriptionDetails": "Subscription detail",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -189,6 +189,7 @@
                     "no_modify_subscription_in_use_by_others": "This subscription can not be modified because it is in use by one or more other subscriptions: {unterminated_parents}"
                 }
             },
+            "subscriptionInstanceId": "Instance ID",
             "ownerSubscriptionId": "Owner subscription ID",
             "inUseByRelations": "In use by relation",
             "showDetails": "Toon details",

--- a/packages/orchestrator-ui-components/src/stories/Button.jsx
+++ b/packages/orchestrator-ui-components/src/stories/Button.jsx
@@ -6,49 +6,55 @@ import './button.css';
  * Primary UI component for user interaction
  */
 export const Button = ({ primary, backgroundColor, size, label, ...props }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
-  return (
-    <button
-      type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
-      {...props}
-    >
-      {label}
-      <style jsx>{`
-        button {
-          background-color: ${backgroundColor};
-        }
-      `}</style>
-    </button>
-  );
+    const mode = primary
+        ? 'storybook-button--primary'
+        : 'storybook-button--secondary';
+    return (
+        <button
+            type="button"
+            className={[
+                'storybook-button',
+                `storybook-button--${size}`,
+                mode,
+            ].join(' ')}
+            {...props}
+        >
+            {label}
+            <style jsx>{`
+                button {
+                    background-color: ${backgroundColor};
+                }
+            `}</style>
+        </button>
+    );
 };
 
 Button.propTypes = {
-  /**
-   * Is this the principal call to action on the page?
-   */
-  primary: PropTypes.bool,
-  /**
-   * What background color to use
-   */
-  backgroundColor: PropTypes.string,
-  /**
-   * How large should the button be?
-   */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /**
-   * Button contents
-   */
-  label: PropTypes.string.isRequired,
-  /**
-   * Optional click handler
-   */
-  onClick: PropTypes.func,
+    /**
+     * Is this the principal call to action on the page?
+     */
+    primary: PropTypes.bool,
+    /**
+     * What background color to use
+     */
+    backgroundColor: PropTypes.string,
+    /**
+     * How large should the button be?
+     */
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
+    /**
+     * Button contents
+     */
+    label: PropTypes.string.isRequired,
+    /**
+     * Optional click handler
+     */
+    onClick: PropTypes.func,
 };
 
 Button.defaultProps = {
-  backgroundColor: null,
-  primary: false,
-  size: 'medium',
-  onClick: undefined,
+    backgroundColor: null,
+    primary: false,
+    size: 'medium',
+    onClick: undefined,
 };

--- a/packages/orchestrator-ui-components/src/stories/Configure.mdx
+++ b/packages/orchestrator-ui-components/src/stories/Configure.mdx
@@ -1,36 +1,38 @@
-import { Meta } from "@storybook/blocks";
-import Image from "next/image";
+import { Meta } from '@storybook/blocks';
+import Image from 'next/image';
 
-import Github from "./assets/github.svg";
-import Discord from "./assets/discord.svg";
-import Youtube from "./assets/youtube.svg";
-import Tutorials from "./assets/tutorials.svg";
-import Styling from "./assets/styling.png";
-import Context from "./assets/context.png";
-import Assets from "./assets/assets.png";
-import Docs from "./assets/docs.png";
-import Share from "./assets/share.png";
-import FigmaPlugin from "./assets/figma-plugin.png";
-import Testing from "./assets/testing.png";
-import Accessibility from "./assets/accessibility.png";
-import Theming from "./assets/theming.png";
-import AddonLibrary from "./assets/addon-library.png";
+import Github from './assets/github.svg';
+import Discord from './assets/discord.svg';
+import Youtube from './assets/youtube.svg';
+import Tutorials from './assets/tutorials.svg';
+import Styling from './assets/styling.png';
+import Context from './assets/context.png';
+import Assets from './assets/assets.png';
+import Docs from './assets/docs.png';
+import Share from './assets/share.png';
+import FigmaPlugin from './assets/figma-plugin.png';
+import Testing from './assets/testing.png';
+import Accessibility from './assets/accessibility.png';
+import Theming from './assets/theming.png';
+import AddonLibrary from './assets/addon-library.png';
 
-export const RightArrow = () => <svg 
-    viewBox="0 0 14 14" 
-    width="8px" 
-    height="14px" 
-    style={{ 
-      marginLeft: '4px',
-      display: 'inline-block',
-      shapeRendering: 'inherit',
-      verticalAlign: 'middle',
-      fill: 'currentColor',
-      'path fill': 'currentColor'
-    }}
->
-  <path d="m11.1 7.35-5.5 5.5a.5.5 0 0 1-.7-.7L10.04 7 4.9 1.85a.5.5 0 1 1 .7-.7l5.5 5.5c.2.2.2.5 0 .7Z" />
-</svg>
+export const RightArrow = () => (
+    <svg
+        viewBox="0 0 14 14"
+        width="8px"
+        height="14px"
+        style={{
+            marginLeft: '4px',
+            display: 'inline-block',
+            shapeRendering: 'inherit',
+            verticalAlign: 'middle',
+            fill: 'currentColor',
+            'path fill': 'currentColor',
+        }}
+    >
+        <path d="m11.1 7.35-5.5 5.5a.5.5 0 0 1-.7-.7L10.04 7 4.9 1.85a.5.5 0 1 1 .7-.7l5.5 5.5c.2.2.2.5 0 .7Z" />
+    </svg>
+);
 
 <Meta title="Configure your project" />
 
@@ -39,6 +41,7 @@ export const RightArrow = () => <svg
     # Configure your project
 
     Because Storybook works separately from your app, you'll need to configure it for your specific stack and setup. Below, explore guides for configuring Storybook with popular frameworks and tools. If you get stuck, learn how you can ask for help from our community.
+
   </div>
   <div className="sb-section">
     <div className="sb-section-item">
@@ -97,6 +100,7 @@ export const RightArrow = () => <svg
     # Do more with Storybook
 
     Now that you know the basics, let's explore other parts of Storybook that will improve your experience. This list is just to get you started. You can customise Storybook in many ways to fit your needs.
+
   </div>
 
   <div className="sb-section">
@@ -234,12 +238,12 @@ export const RightArrow = () => <svg
       >Star on GitHub<RightArrow /></a>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={33}
         height={32}
         layout="fixed"
-        src={Discord} 
-        alt="Discord logo" 
+        src={Discord}
+        alt="Discord logo"
         className="sb-explore-image"
       />
       <div>
@@ -252,12 +256,12 @@ export const RightArrow = () => <svg
       </div>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={32}
         height={32}
         layout="fixed"
-        src={Youtube} 
-        alt="Youtube logo" 
+        src={Youtube}
+        alt="Youtube logo"
         className="sb-explore-image"
       />
       <div>
@@ -270,12 +274,12 @@ export const RightArrow = () => <svg
       </div>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={33}
         height={32}
         layout="fixed"
-        src={Tutorials} 
-        alt="A book" 
+        src={Tutorials}
+        alt="A book"
         className="sb-explore-image"
       />
       <p>Follow guided walkthroughs on for key workflows.</p>
@@ -285,10 +289,11 @@ export const RightArrow = () => <svg
           target="_blank"
         >Discover tutorials<RightArrow /></a>
     </div>
+
 </div>
 
 <style>
-  {`
+    {`
   .sb-container {
     margin-bottom: 48px;
   }

--- a/packages/orchestrator-ui-components/src/stories/Header.jsx
+++ b/packages/orchestrator-ui-components/src/stories/Header.jsx
@@ -5,55 +5,69 @@ import { Button } from './Button';
 import './header.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
-  <header>
-    <div className="storybook-header">
-      <div>
-        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-          <g fill="none" fillRule="evenodd">
-            <path
-              d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
-              fill="#FFF"
-            />
-            <path
-              d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
-              fill="#555AB9"
-            />
-            <path
-              d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
-              fill="#91BAF8"
-            />
-          </g>
-        </svg>
-        <h1>Acme</h1>
-      </div>
-      <div>
-        {user ? (
-          <>
-            <span className="welcome">
-              Welcome, <b>{user.name}</b>!
-            </span>
-            <Button size="small" onClick={onLogout} label="Log out" />
-          </>
-        ) : (
-          <>
-            <Button size="small" onClick={onLogin} label="Log in" />
-            <Button primary size="small" onClick={onCreateAccount} label="Sign up" />
-          </>
-        )}
-      </div>
-    </div>
-  </header>
+    <header>
+        <div className="storybook-header">
+            <div>
+                <svg
+                    width="32"
+                    height="32"
+                    viewBox="0 0 32 32"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <g fill="none" fillRule="evenodd">
+                        <path
+                            d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+                            fill="#FFF"
+                        />
+                        <path
+                            d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+                            fill="#555AB9"
+                        />
+                        <path
+                            d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
+                            fill="#91BAF8"
+                        />
+                    </g>
+                </svg>
+                <h1>Acme</h1>
+            </div>
+            <div>
+                {user ? (
+                    <>
+                        <span className="welcome">
+                            Welcome, <b>{user.name}</b>!
+                        </span>
+                        <Button
+                            size="small"
+                            onClick={onLogout}
+                            label="Log out"
+                        />
+                    </>
+                ) : (
+                    <>
+                        <Button size="small" onClick={onLogin} label="Log in" />
+                        <Button
+                            primary
+                            size="small"
+                            onClick={onCreateAccount}
+                            label="Sign up"
+                        />
+                    </>
+                )}
+            </div>
+        </div>
+    </header>
 );
 
 Header.propTypes = {
-  user: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-  }),
-  onLogin: PropTypes.func.isRequired,
-  onLogout: PropTypes.func.isRequired,
-  onCreateAccount: PropTypes.func.isRequired,
+    user: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+    }),
+    onLogin: PropTypes.func.isRequired,
+    onLogout: PropTypes.func.isRequired,
+    onCreateAccount: PropTypes.func.isRequired,
 };
 
 Header.defaultProps = {
-  user: null,
+    user: null,
 };

--- a/packages/orchestrator-ui-components/src/stories/Page.jsx
+++ b/packages/orchestrator-ui-components/src/stories/Page.jsx
@@ -4,65 +4,86 @@ import { Header } from './Header';
 import './page.css';
 
 export const Page = () => {
-  const [user, setUser] = React.useState();
+    const [user, setUser] = React.useState();
 
-  return (
-    <article>
-      <Header
-        user={user}
-        onLogin={() => setUser({ name: 'Jane Doe' })}
-        onLogout={() => setUser(undefined)}
-        onCreateAccount={() => setUser({ name: 'Jane Doe' })}
-      />
-      <section className="storybook-page">
-        <h2>Pages in Storybook</h2>
-        <p>
-          We recommend building UIs with a{' '}
-          <a href="https://componentdriven.org" target="_blank" rel="noopener noreferrer">
-            <strong>component-driven</strong>
-          </a>{' '}
-          process starting with atomic components and ending with pages.
-        </p>
-        <p>
-          Render pages with mock data. This makes it easy to build and review page states without
-          needing to navigate to them in your app. Here are some handy patterns for managing page
-          data in Storybook:
-        </p>
-        <ul>
-          <li>
-            Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
-          </li>
-          <li>
-            Assemble data in the page component from your services. You can mock these services out
-            using Storybook.
-          </li>
-        </ul>
-        <p>
-          Get a guided tutorial on component-driven development at{' '}
-          <a href="https://storybook.js.org/tutorials/" target="_blank" rel="noopener noreferrer">
-            Storybook tutorials
-          </a>
-          . Read more in the{' '}
-          <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer">
-            docs
-          </a>
-          .
-        </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
-          <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-            <g fill="none" fillRule="evenodd">
-              <path
-                d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
-                id="a"
-                fill="#999"
-              />
-            </g>
-          </svg>
-          Viewports addon in the toolbar
-        </div>
-      </section>
-    </article>
-  );
+    return (
+        <article>
+            <Header
+                user={user}
+                onLogin={() => setUser({ name: 'Jane Doe' })}
+                onLogout={() => setUser(undefined)}
+                onCreateAccount={() => setUser({ name: 'Jane Doe' })}
+            />
+            <section className="storybook-page">
+                <h2>Pages in Storybook</h2>
+                <p>
+                    We recommend building UIs with a{' '}
+                    <a
+                        href="https://componentdriven.org"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <strong>component-driven</strong>
+                    </a>{' '}
+                    process starting with atomic components and ending with
+                    pages.
+                </p>
+                <p>
+                    Render pages with mock data. This makes it easy to build and
+                    review page states without needing to navigate to them in
+                    your app. Here are some handy patterns for managing page
+                    data in Storybook:
+                </p>
+                <ul>
+                    <li>
+                        Use a higher-level connected component. Storybook helps
+                        you compose such data from the "args" of child component
+                        stories
+                    </li>
+                    <li>
+                        Assemble data in the page component from your services.
+                        You can mock these services out using Storybook.
+                    </li>
+                </ul>
+                <p>
+                    Get a guided tutorial on component-driven development at{' '}
+                    <a
+                        href="https://storybook.js.org/tutorials/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Storybook tutorials
+                    </a>
+                    . Read more in the{' '}
+                    <a
+                        href="https://storybook.js.org/docs"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        docs
+                    </a>
+                    .
+                </p>
+                <div className="tip-wrapper">
+                    <span className="tip">Tip</span> Adjust the width of the
+                    canvas with the{' '}
+                    <svg
+                        width="10"
+                        height="10"
+                        viewBox="0 0 12 12"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <g fill="none" fillRule="evenodd">
+                            <path
+                                d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
+                                id="a"
+                                fill="#999"
+                            />
+                        </g>
+                    </svg>
+                    Viewports addon in the toolbar
+                </div>
+            </section>
+        </article>
+    );
 };

--- a/packages/orchestrator-ui-components/src/stories/button.css
+++ b/packages/orchestrator-ui-components/src/stories/button.css
@@ -1,30 +1,30 @@
 .storybook-button {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 700;
-  border: 0;
-  border-radius: 3em;
-  cursor: pointer;
-  display: inline-block;
-  line-height: 1;
+    font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    border: 0;
+    border-radius: 3em;
+    cursor: pointer;
+    display: inline-block;
+    line-height: 1;
 }
 .storybook-button--primary {
-  color: white;
-  background-color: #1ea7fd;
+    color: white;
+    background-color: #1ea7fd;
 }
 .storybook-button--secondary {
-  color: #333;
-  background-color: transparent;
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+    color: #333;
+    background-color: transparent;
+    box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
 }
 .storybook-button--small {
-  font-size: 12px;
-  padding: 10px 16px;
+    font-size: 12px;
+    padding: 10px 16px;
 }
 .storybook-button--medium {
-  font-size: 14px;
-  padding: 11px 20px;
+    font-size: 14px;
+    padding: 11px 20px;
 }
 .storybook-button--large {
-  font-size: 16px;
-  padding: 12px 24px;
+    font-size: 16px;
+    padding: 12px 24px;
 }

--- a/packages/orchestrator-ui-components/src/stories/colors.mdx
+++ b/packages/orchestrator-ui-components/src/stories/colors.mdx
@@ -1,6 +1,12 @@
-import { ColorPallete, ColorItem, Meta, Title, Description } from '@storybook/blocks'
-import { Colors }  from './colors'
+import {
+    ColorPallete,
+    ColorItem,
+    Meta,
+    Title,
+    Description,
+} from '@storybook/blocks';
+import { Colors } from './colors';
 
 # Colors
+
 <Colors />
- 

--- a/packages/orchestrator-ui-components/src/stories/header.css
+++ b/packages/orchestrator-ui-components/src/stories/header.css
@@ -1,32 +1,32 @@
 .storybook-header {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 15px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 15px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .storybook-header svg {
-  display: inline-block;
-  vertical-align: top;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .storybook-header h1 {
-  font-weight: 700;
-  font-size: 20px;
-  line-height: 1;
-  margin: 6px 0 6px 10px;
-  display: inline-block;
-  vertical-align: top;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 1;
+    margin: 6px 0 6px 10px;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .storybook-header button + button {
-  margin-left: 10px;
+    margin-left: 10px;
 }
 
 .storybook-header .welcome {
-  color: #333;
-  font-size: 14px;
-  margin-right: 10px;
+    color: #333;
+    font-size: 14px;
+    margin-right: 10px;
 }

--- a/packages/orchestrator-ui-components/src/stories/page.css
+++ b/packages/orchestrator-ui-components/src/stories/page.css
@@ -1,69 +1,69 @@
 .storybook-page {
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  padding: 48px 20px;
-  margin: 0 auto;
-  max-width: 600px;
-  color: #333;
+    font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 24px;
+    padding: 48px 20px;
+    margin: 0 auto;
+    max-width: 600px;
+    color: #333;
 }
 
 .storybook-page h2 {
-  font-weight: 700;
-  font-size: 32px;
-  line-height: 1;
-  margin: 0 0 4px;
-  display: inline-block;
-  vertical-align: top;
+    font-weight: 700;
+    font-size: 32px;
+    line-height: 1;
+    margin: 0 0 4px;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .storybook-page p {
-  margin: 1em 0;
+    margin: 1em 0;
 }
 
 .storybook-page a {
-  text-decoration: none;
-  color: #1ea7fd;
+    text-decoration: none;
+    color: #1ea7fd;
 }
 
 .storybook-page ul {
-  padding-left: 30px;
-  margin: 1em 0;
+    padding-left: 30px;
+    margin: 1em 0;
 }
 
 .storybook-page li {
-  margin-bottom: 8px;
+    margin-bottom: 8px;
 }
 
 .storybook-page .tip {
-  display: inline-block;
-  border-radius: 1em;
-  font-size: 11px;
-  line-height: 12px;
-  font-weight: 700;
-  background: #e7fdd8;
-  color: #66bf3c;
-  padding: 4px 12px;
-  margin-right: 10px;
-  vertical-align: top;
+    display: inline-block;
+    border-radius: 1em;
+    font-size: 11px;
+    line-height: 12px;
+    font-weight: 700;
+    background: #e7fdd8;
+    color: #66bf3c;
+    padding: 4px 12px;
+    margin-right: 10px;
+    vertical-align: top;
 }
 
 .storybook-page .tip-wrapper {
-  font-size: 13px;
-  line-height: 20px;
-  margin-top: 40px;
-  margin-bottom: 40px;
+    font-size: 13px;
+    line-height: 20px;
+    margin-top: 40px;
+    margin-bottom: 40px;
 }
 
 .storybook-page .tip-wrapper svg {
-  display: inline-block;
-  height: 12px;
-  width: 12px;
-  margin-right: 4px;
-  vertical-align: top;
-  margin-top: 3px;
+    display: inline-block;
+    height: 12px;
+    width: 12px;
+    margin-right: 4px;
+    vertical-align: top;
+    margin-top: 3px;
 }
 
 .storybook-page .tip-wrapper svg path {
-  fill: #1ea7fd;
+    fill: #1ea7fd;
 }

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -8,7 +8,7 @@ type GenericField = { [key: string]: number | string | boolean };
 
 export type FieldValue = {
     field: string;
-    value: string | number;
+    value: string | number | boolean;
 };
 
 export type KeyValue = {
@@ -32,12 +32,18 @@ export type ResourceTypeBase = {
     label?: string;
 } & GenericField;
 
+export type InUseByRelation = {
+    subscription_instance_id: string;
+    subscription_id: string;
+};
+
 export type ProductBlockInstance = {
     id: number;
     ownerSubscriptionId: string;
     subscriptionInstanceId: string;
     parent: Nullable<number>;
     productBlockInstanceValues: FieldValue[];
+    inUseByRelations: InUseByRelation[];
 };
 
 export interface ResourceTypeDefinition {
@@ -91,7 +97,7 @@ export interface FixedInputDefinition {
 
 export interface TreeBlock extends ProductBlockInstance {
     icon: string;
-    label: string | number;
+    label: string | number | boolean;
     callback: () => void;
     children: TreeBlock[];
 }

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -35,6 +35,7 @@ export type ResourceTypeBase = {
 export type ProductBlockInstance = {
     id: number;
     ownerSubscriptionId: string;
+    subscriptionInstanceId: string;
     parent: Nullable<number>;
     productBlockInstanceValues: FieldValue[];
 };

--- a/packages/orchestrator-ui-components/src/utils/getTokenName.ts
+++ b/packages/orchestrator-ui-components/src/utils/getTokenName.ts
@@ -1,4 +1,5 @@
-export function getTokenName(name: string | number): string {
+export function getTokenName(name: string | number | boolean): string {
+    if (typeof name === 'boolean') return 'tokenConstant';
     const icons: { [key: string]: string } = {
         Node: 'tokenNamespace',
         'IP BGP Service Settings': 'tokenEnumMember',

--- a/packages/orchestrator-ui-components/src/utils/string.spec.ts
+++ b/packages/orchestrator-ui-components/src/utils/string.spec.ts
@@ -1,4 +1,4 @@
-import { removeSuffix, upperCaseFirstChar } from './strings';
+import { camelToHuman, removeSuffix, upperCaseFirstChar } from './strings';
 
 describe('upperCaseFirstChar()', () => {
     it("Doesn't crash on an empty string but returns empty string", () => {
@@ -43,5 +43,28 @@ describe('removeSuffix()', () => {
     it('Works ok for strings without splitChar', () => {
         const result = removeSuffix('a=b');
         expect(result).toEqual('a=b');
+    });
+});
+
+describe('camelToHuman()', () => {
+    it("Doesn't crash on an empty string but returns empty string", () => {
+        const result = camelToHuman('');
+        expect(result).toEqual('');
+    });
+    it('Works ok for lowercase strings with length 1', () => {
+        const result = camelToHuman('a');
+        expect(result).toEqual('A');
+    });
+    it('Works ok for uppercase strings with length 1', () => {
+        const result = camelToHuman('A');
+        expect(result).toEqual('A');
+    });
+    it('Works ok for strings starting with an lowercase char', () => {
+        const result = camelToHuman('aQuickBrownFox');
+        expect(result).toEqual('A Quick Brown Fox');
+    });
+    it('Works ok for strings starting with an uppercase char', () => {
+        const result = camelToHuman('AQuickBrownFox');
+        expect(result).toEqual('A Quick Brown Fox');
     });
 });

--- a/packages/orchestrator-ui-components/src/utils/strings.ts
+++ b/packages/orchestrator-ui-components/src/utils/strings.ts
@@ -8,3 +8,8 @@ export const removeSuffix = (value: string, splitChar = '?'): string => {
     if (value.length <= 1 || !value.includes(splitChar)) return value;
     return value.split(splitChar).slice(0, -1).join();
 };
+
+export const camelToHuman = (value: string): string => {
+    const result = value.replace(/([A-Z])/g, ' $1').trimStart();
+    return result.charAt(0).toUpperCase() + result.slice(1);
+};


### PR DESCRIPTION
Implementation for https://github.com/workfloworchestrator/orchestrator-ui/issues/282

- [x] Hide empty rows (resource type with no value)
- [x] Move inline styles to styles.ts
- [x] Set default subscription detail tab back to "General"

NOTE: we might want to broaden our linting rules: the last commit contains the results from: `yarn prettier --write .` : which also linted some .jsx stories...