### PR TITLE
Try to get AWS build working

### DIFF
--- a/apps/wfo-ui/configuration/configuration.ts
+++ b/apps/wfo-ui/configuration/configuration.ts
@@ -47,6 +47,6 @@ export const getInitialOrchestratorConfig = (): OrchestratorConfig => {
                 PROCESS_DETAIL_DEFAULT_REFETCH_INTERVAL,
             ),
         },
-        authActive: process.env.AUTH_ACTIVE?.toLowerCase() != 'false',
+        authActive: false,
     };
 };


### PR DESCRIPTION
So this works. Indicating that somehow the new way of providing ENV vars doens't seem to work at all with AWS:

https://test-auth-env.d2zs5rahejck1g.amplifyapp.com/

![Schermafbeelding 2023-11-17 om 13 12 02](https://github.com/workfloworchestrator/orchestrator-ui/assets/685002/5ad2b8ba-0d6c-493a-bd4b-ac27a6003886)

Todo:
- [ ] find out if it's possible to add runtime env's or find out why they are swallowed.

