### PR TITLE
414 - Release before moving to absolute imports

### DIFF
--- a/.changeset/little-ducks-guess.md
+++ b/.changeset/little-ducks-guess.md
@@ -1,0 +1,8 @@
+---
+'@orchestrator-ui/eslint-config-custom': patch
+'@orchestrator-ui/jest-config': patch
+'@orchestrator-ui/orchestrator-ui-components': patch
+'@orchestrator-ui/tsconfig': patch
+---
+
+Test release before adding absolute imports (issue 414)


### PR DESCRIPTION
This is a test release to be a baseline for the next change in this ticket: moving to absolute imports