### PR TITLE
414 absolute imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     "trailingComma": "all",
     "bracketSpacing": true,
     "importOrder": [
-        "^react", "^react-native", "^[a-zA-Z]", "^@?\\w", "^[./]"
+        "^react", "^react-native", "^[a-zA-Z]", "^@?\\w", "^@/?\\w", "^[./]"
     ],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true,

--- a/apps/wfo-ui-surf/pages/_app.tsx
+++ b/apps/wfo-ui-surf/pages/_app.tsx
@@ -25,14 +25,14 @@ import {
     defaultOrchestratorTheme,
 } from '@orchestrator-ui/orchestrator-ui-components';
 
-import { getAppLogo } from '../components/AppLogo/AppLogo';
+import { getAppLogo } from '@/components/AppLogo/AppLogo';
 import {
     getInitialOrchestratorConfig,
     getInitialSurfConfig,
-} from '../configuration';
-import { PATH_SERVICE_TICKETS } from '../constants-surf';
-import { SurfConfig, SurfConfigProvider } from '../contexts/surfConfigContext';
-import { TranslationsProvider } from '../translations/translationsProvider';
+} from '@/configuration';
+import { PATH_SERVICE_TICKETS } from '@/constants-surf';
+import { SurfConfig, SurfConfigProvider } from '@/contexts/surfConfigContext';
+import { TranslationsProvider } from '@/translations/translationsProvider';
 
 type AppOwnProps = {
     orchestratorConfig: OrchestratorConfig;

--- a/apps/wfo-ui-surf/tsconfig.json
+++ b/apps/wfo-ui-surf/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "@orchestrator-ui/tsconfig/nextjs.json",
     "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./*"]
+        },
         "plugins": [
             {
                 "name": "next"

--- a/apps/wfo-ui/pages/_app.tsx
+++ b/apps/wfo-ui/pages/_app.tsx
@@ -24,9 +24,9 @@ import {
     defaultOrchestratorTheme,
 } from '@orchestrator-ui/orchestrator-ui-components';
 
-import { getAppLogo } from '../components/AppLogo/AppLogo';
-import { getInitialOrchestratorConfig } from '../configuration';
-import { TranslationsProvider } from '../translations/translationsProvider';
+import { getAppLogo } from '@/components/AppLogo/AppLogo';
+import { getInitialOrchestratorConfig } from '@/configuration';
+import { TranslationsProvider } from '@/translations/translationsProvider';
 
 type AppOwnProps = { orchestratorConfig: OrchestratorConfig };
 

--- a/apps/wfo-ui/tsconfig.json
+++ b/apps/wfo-ui/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "extends": "@orchestrator-ui/tsconfig/nextjs.json",
     "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./*"]
+        },
         "plugins": [
             {
                 "name": "next"

--- a/packages/orchestrator-ui-components/src/components/WfoAuth/WfoAuth.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoAuth/WfoAuth.tsx
@@ -2,8 +2,8 @@ import React, { JSX, useContext } from 'react';
 
 import { useSession } from 'next-auth/react';
 
-import { OrchestratorConfigContext } from '../../contexts';
-import { WfoLoading } from '../WfoLoading';
+import { WfoLoading } from '@/components';
+import { OrchestratorConfigContext } from '@/contexts';
 
 interface AuthProps {
     children: JSX.Element;

--- a/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoListItemStartPage.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoListItemStartPage.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiTextColor } from '@elastic/eui';
 
-import { ProcessFromRestApi, ProductDefinition } from '../../types';
+import { ProcessFromRestApi, ProductDefinition } from '@/types';
 
 interface Subscription {
     name: string;

--- a/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoListStartPage.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoListStartPage.tsx
@@ -8,7 +8,8 @@ import {
     EuiSpacer,
 } from '@elastic/eui';
 
-import { ItemsList } from '../../types';
+import { ItemsList } from '@/types';
+
 import { WfoListItemStartPage } from './WfoListItemStartPage';
 
 interface WfoListStartPage {

--- a/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoMultiListSection.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoMultiListSection.tsx
@@ -6,7 +6,8 @@ import {
     useFavouriteSubscriptions,
     useProcessesAttention,
     useRecentProcesses,
-} from '../../hooks/DataFetchHooks';
+} from '@/hooks';
+
 import WfoListStartPage from './WfoListStartPage';
 
 export const WfoMultiListSection: FC = () => {

--- a/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoNewProcessPanel.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoNewProcessPanel.tsx
@@ -8,7 +8,7 @@ import {
     EuiTextColor,
 } from '@elastic/eui';
 
-import { WfoFrequentlyUsed } from './WfoFrequentlyUsed';
+import { WfoFrequentlyUsed } from '@/components';
 
 export const WfoNewProcessPanel: FC = () => {
     const [value, setValue] = useState('');

--- a/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoStatCards.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoStartPage/WfoStatCards.tsx
@@ -8,8 +8,8 @@ import {
     EuiText,
 } from '@elastic/eui';
 
-import { useOrchestratorTheme } from '../../hooks/useOrchestratorTheme';
-import { TotalStat } from '../../types';
+import { useOrchestratorTheme } from '@/hooks';
+import { TotalStat } from '@/types';
 
 const totalStats: TotalStat[] = [
     {

--- a/packages/orchestrator-ui-components/tsconfig.build.json
+++ b/packages/orchestrator-ui-components/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
     "extends": "@orchestrator-ui/tsconfig/base.json",
     "compilerOptions": {
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"]
+        }
     },
     "include": ["**/*.ts", "**/*.tsx"],
     "exclude": [

--- a/packages/orchestrator-ui-components/tsconfig.json
+++ b/packages/orchestrator-ui-components/tsconfig.json
@@ -3,7 +3,11 @@
     "compilerOptions": {
         "strictNullChecks": true,
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"]
+        }
     },
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
     "exclude": [


### PR DESCRIPTION
#414 

- Adds absolute imports in tsconfig for wfo-ui, wfo-ui-surf and orchestrator-ui-components
- Adds prettier rule to place the @/.... under the library imports as a separate group
- Fixes all imports in wfo-ui
- Fixes imports in _app.tsx for wfo-ui-surf
- Fixes imports in WfoStartPage components in orchestrator-ui-components

- [x] Wait for deployment in Okteto