### PR TITLE
414 - Moves all devDependencies into the dependencies section

### DIFF
--- a/.changeset/popular-dragons-flow.md
+++ b/.changeset/popular-dragons-flow.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/eslint-config-custom': patch
+---
+
+Moves all devDependencies into the dependencies section

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -7,7 +7,7 @@
         "dev": "yarn build -- --watch",
         "reset": "rm -rf node_modules"
     },
-    "devDependencies": {
+    "dependencies": {
         "@typescript-eslint/eslint-plugin": "6.2.0",
         "eslint": "^8.48.0",
         "eslint-config-next": "^13.4.1",


### PR DESCRIPTION
#414 

The eslint-config-custom package is used as a devDependency. The dependencies inside the eslint-config-custom should be in the dependencies section to be installed by a consumer of that package