### PR TITLE
435 Adds confirmation dialog when navigating a step back in the form

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoForms/UserInputForm.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoForms/UserInputForm.tsx
@@ -399,13 +399,17 @@ function UserInputForm({
     const [nrOfValidationErrors, setNrOfValidationErrors] = useState<number>(0);
     const [rootErrors, setRootErrors] = useState<string[]>([]);
 
-    const openDialog = () => {
-        showConfirmDialog({
-            question: '',
-            confirmAction: () => {},
-            cancelAction: cancel,
-            leavePage: true,
-        });
+    const openLeavePageDialog = (
+        leaveAction: ConfirmDialogActions['closeConfirmDialog'],
+        leaveQuestion?: string,
+    ) => {
+        return () =>
+            showConfirmDialog({
+                question: leaveQuestion || '',
+                confirmAction: () => {},
+                cancelAction: leaveAction,
+                leavePage: true,
+            });
     };
 
     const submit = async (userInput: any = {}) => {
@@ -484,7 +488,11 @@ function UserInputForm({
                 fill
                 color={buttons.previous.color ?? 'primary'}
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                    onButtonClick(e, buttons.previous.dialog, previous);
+                    onButtonClick(
+                        e,
+                        buttons.previous.dialog,
+                        openLeavePageDialog(previous, t('previousQuestion')),
+                    );
                 }}
             >
                 {buttons.previous.text ?? t('previous')}
@@ -492,7 +500,11 @@ function UserInputForm({
         ) : !isResuming ? (
             <div
                 onClick={(e) => {
-                    onButtonClick(e, buttons.previous.dialog, openDialog);
+                    onButtonClick(
+                        e,
+                        buttons.previous.dialog,
+                        openLeavePageDialog(cancel),
+                    );
                 }}
                 css={{
                     cursor: 'pointer',

--- a/packages/orchestrator-ui-components/src/components/confirmationDialog/WfoConfirmationDialog.tsx
+++ b/packages/orchestrator-ui-components/src/components/confirmationDialog/WfoConfirmationDialog.tsx
@@ -81,7 +81,7 @@ export default function WfoConfirmationDialog({
                 <EuiModal
                     css={confirmationDialogStyling}
                     className="confirm-modal"
-                    onClose={cancel}
+                    onClose={leavePage ? confirm : cancel}
                     initialFocus="[name=popfirst]"
                 >
                     <EuiModalHeader>

--- a/packages/orchestrator-ui-components/src/components/confirmationDialog/WfoConfirmationDialog.tsx
+++ b/packages/orchestrator-ui-components/src/components/confirmationDialog/WfoConfirmationDialog.tsx
@@ -62,8 +62,8 @@ export default function WfoConfirmationDialog({
                 <section
                     className={`dialog-content ${isError ? ' error' : ''}`}
                 >
-                    <h2>{t('leavePage')}</h2>
-                    <p>{t('leavePageSub')}</p>
+                    <h2>{question || t('leavePage')}</h2>
+                    {!question && <p>{t('leavePageSub')}</p>}
                 </section>
             ) : (
                 <section className="dialog-content">

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -48,6 +48,7 @@
             "cancel": "Cancel",
             "submit": "Submit",
             "previous": "Previous",
+            "previousQuestion": "Are you sure to leave this page? Any data filled on this page will be lost",
             "startTask": "Start task",
             "startWorkflow": "Start workflow",
             "resumeTask": "Resume task",

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -48,7 +48,7 @@
             "cancel": "Cancel",
             "submit": "Submit",
             "previous": "Previous",
-            "previousQuestion": "Are you sure to leave this page? Any data filled on this page will be lost",
+            "previousQuestion": "Are you sure you want to leave this page? Any filled form data will be lost",
             "startTask": "Start task",
             "startWorkflow": "Start workflow",
             "resumeTask": "Resume task",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -49,6 +49,7 @@
             "submit": "Verstuur",
             "previous": "Vorige",
             "startTask": "Start taak",
+            "previousQuestion": "Weet je zeker dat je deze pagina wilt verlaten? Ingevulde velden worden niet opgeslagen",
             "startWorkflow": "Start workflow",
             "resumeTask": "Hervat task",
             "resumeWorkflow": "Hervat workflow",


### PR DESCRIPTION
#435 #557 

- Adds confirm dialog when jumping back 1 step in forms
- Makes the leave-page-question overridable (without breaking existing implementations)
![image](https://github.com/workfloworchestrator/orchestrator-ui/assets/20791917/d7590dc9-067e-4da1-a7db-3d96aab7a7fe)
