### PR TITLE
545: Change default caching behaviour

### DIFF
--- a/apps/wfo-ui/pages/_app.tsx
+++ b/apps/wfo-ui/pages/_app.tsx
@@ -35,8 +35,7 @@ type AppOwnProps = { orchestratorConfig: OrchestratorConfig };
 const queryClientConfig: QueryClientConfig = {
     defaultOptions: {
         queries: {
-            staleTime: 1 * 60 * 60 * 1000,
-            cacheTime: 5 * 60 * 60 * 1000,
+            cacheTime: 5 * 1000,
             refetchOnWindowFocus: true,
             keepPreviousData: true,
         },


### PR DESCRIPTION
This closes https://github.com/workfloworchestrator/orchestrator-ui/issues/545 and https://github.com/workfloworchestrator/orchestrator-ui/issues/542

The keepPreviousData property seems to solve the problem of loading state when fetching additional pages. It keeps the data until the new data is loaded. Removing stale time makes sure data for a subscription is refreshed after a modify workflow is triggered solving 542. There are probably more fine grained and elegant solutions here but since we will have other tickets dealing with state and data retrieval is thought it was best to make a minimal fix here. 


