### PR TITLE
Fix query error in WfoSubscriptionNoteEdit by using existing data

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoInlineNoteEdit/WfoSubscriptionNoteEdit.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoInlineNoteEdit/WfoSubscriptionNoteEdit.tsx
@@ -1,41 +1,32 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import { ApiResult, SubscriptionListResponse, UseQuery } from '@/rtk';
 import { useStartProcessMutation } from '@/rtk/endpoints/forms';
 import { useUpdateSubscriptionNoteOptimisticMutation } from '@/rtk/endpoints/subscriptionListMutation';
-import { Subscription } from '@/types';
 import { INVISIBLE_CHARACTER } from '@/utils';
 
 import { WfoInlineEdit } from '../WfoInlineEdit';
+import { SubscriptionListItem } from '../WfoSubscriptionsList';
 
 interface WfoSubscriptionNoteEditProps {
-    subscriptionId: Subscription['subscriptionId'];
     onlyShowOnHover?: boolean;
     queryVariables: Record<string, unknown>;
-    useQuery: UseQuery<SubscriptionListResponse, Subscription>;
+    endpointName: string | undefined;
+    subscription: SubscriptionListItem;
 }
 
 export const WfoSubscriptionNoteEdit: FC<WfoSubscriptionNoteEditProps> = ({
-    subscriptionId,
     onlyShowOnHover = false,
     queryVariables,
-    useQuery,
+    endpointName,
+    subscription,
 }) => {
-    const { selectedItem } = useQuery(queryVariables, {
-        selectFromResult: (result: ApiResult<SubscriptionListResponse>) => ({
-            selectedItem: result?.data?.subscriptions?.find(
-                (sub) => sub.subscriptionId === subscriptionId,
-            ),
-        }),
-    });
-    const endpointName = useQuery().endpointName;
     const [startProcess] = useStartProcessMutation();
     const [updateSub] = useUpdateSubscriptionNoteOptimisticMutation();
 
     const triggerNoteModifyWorkflow = (note: string) => {
         const noteModifyPayload = [
-            { subscription_id: subscriptionId },
+            { subscription_id: subscription.subscriptionId },
             { note: note === INVISIBLE_CHARACTER ? '' : note },
         ];
         startProcess({
@@ -45,7 +36,7 @@ export const WfoSubscriptionNoteEdit: FC<WfoSubscriptionNoteEditProps> = ({
 
         updateSub({
             queryName: endpointName ?? '',
-            subscriptionId: subscriptionId,
+            subscriptionId: subscription.subscriptionId,
             graphQlQueryVariables: queryVariables,
             note: note,
         });
@@ -54,8 +45,8 @@ export const WfoSubscriptionNoteEdit: FC<WfoSubscriptionNoteEditProps> = ({
     return (
         <WfoInlineEdit
             value={
-                selectedItem?.note?.trim()
-                    ? selectedItem.note
+                subscription?.note?.trim()
+                    ? subscription.note
                     : INVISIBLE_CHARACTER
             }
             onlyShowOnHover={onlyShowOnHover}

--- a/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionResultMappers.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscriptionsList/subscriptionResultMappers.ts
@@ -20,9 +20,10 @@ export const mapGraphQlSubscriptionsResultToPageInfo = (
 ) => graphqlResponse.pageInfo;
 
 export const mapGraphQlSubscriptionsResultToSubscriptionListItems = (
-    graphqlResponse: SubscriptionListResponse,
-): SubscriptionListItem[] =>
-    graphqlResponse.subscriptions.map((subscription) => {
+    graphqlResponse: SubscriptionListResponse | undefined,
+): SubscriptionListItem[] => {
+    if (!graphqlResponse) return [];
+    return graphqlResponse.subscriptions.map((subscription) => {
         const {
             description,
             insync,
@@ -55,3 +56,4 @@ export const mapGraphQlSubscriptionsResultToSubscriptionListItems = (
             metadata: Object.keys(metadata).length > 0 ? metadata : null,
         };
     });
+};


### PR DESCRIPTION
the component was re-fetching data without query variables which resulted in query errors `const endpointName = useQuery().endpointName;` but was also confused why the data is refetched

- change WfoSubscriptionNoteEdit to use existing data
- clean WfoSubscriptionsList and move the subscription list fetch above the table columns so the list can be used in WfoSubscriptionNoteEdit. (also cleaned up the html)
- change subscriptionResultMappers to work with response or undefined and returns empty list when undefined.