### PR TITLE
1952 WfoTable: Resets page index to 0 when search query is updated

### DIFF
--- a/.changeset/easy-candies-mix.md
+++ b/.changeset/easy-candies-mix.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+1952 WfoTable: Resets page index to 0 when search query is updated. Always shows the current page in the pagination section, even when it is out of range.

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoTable/WfoTable.tsx
@@ -13,6 +13,7 @@ import {
     WfoDataSorting,
 } from '../utils/columns';
 import { DEFAULT_PAGE_SIZES } from '../utils/constants';
+import { getPageCount } from '../utils/tableUtils';
 import { WfoTableDataRows } from './WfoTableDataRows';
 import { WfoTableHeaderRow } from './WfoTableHeaderRow';
 import { getWfoTableStyles } from './styles';
@@ -232,9 +233,7 @@ export const WfoTable = <T extends object>({
                 <div css={paginationStyle}>
                     <EuiSpacer size="xs" />
                     <EuiTablePagination
-                        pageCount={Math.ceil(
-                            pagination.totalItemCount / pagination.pageSize,
-                        )}
+                        pageCount={getPageCount(pagination)}
                         activePage={pagination.pageIndex}
                         itemsPerPage={pagination.pageSize}
                         itemsPerPageOptions={

--- a/packages/orchestrator-ui-components/src/components/WfoTable/utils/tableUtils.spec.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/utils/tableUtils.spec.ts
@@ -1,7 +1,10 @@
+import { Pagination } from '@/components';
+
 import { SortOrder } from '../../../types';
 import {
     determineNewSortOrder,
     determinePageIndex,
+    getPageCount,
     hasSpecialCharacterOrSpace,
 } from './tableUtils';
 
@@ -101,6 +104,32 @@ describe('tableUtils', () => {
 
         it('should return true for strings with only special characters', () => {
             expect(hasSpecialCharacterOrSpace('@#$%^&*')).toBe(true);
+        });
+    });
+
+    describe('getPageCount', () => {
+        it('returns the page count', () => {
+            const pagination: Pagination = {
+                pageIndex: 0,
+                pageSize: 10,
+                totalItemCount: 101,
+            };
+
+            const result = getPageCount(pagination);
+
+            expect(result).toEqual(11);
+        });
+
+        it('returns the current page as value when the current page is out of range', () => {
+            const pagination: Pagination = {
+                pageIndex: 50,
+                pageSize: 10,
+                totalItemCount: 101,
+            };
+
+            const result = getPageCount(pagination);
+
+            expect(result).toEqual(51);
         });
     });
 });

--- a/packages/orchestrator-ui-components/src/components/WfoTable/utils/tableUtils.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/utils/tableUtils.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '@/components';
 import type { DataDisplayReturnValues } from '@/hooks';
 import { SortOrder } from '@/types';
 
@@ -63,4 +64,12 @@ export const getQueryStringHandler =
                 ? `${queryString}*`
                 : queryString;
         setDataDisplayParam('queryString', query);
+        setDataDisplayParam('pageIndex', 0);
     };
+
+export const getPageCount = (pagination: Pagination) =>
+    // In case the pageIndex is out of range calculated by totalItemCount and pageSize, the pageIndex should be returned to be transparent to the user
+    Math.max(
+        Math.ceil(pagination.totalItemCount / pagination.pageSize),
+        pagination.pageIndex + 1,
+    );


### PR DESCRIPTION
WfoTable:
- Resets page index to 0 when search query is updated
- Always shows the current page in the pagination section, even when it is out of range

![image](https://github.com/user-attachments/assets/619cf619-4eb3-45c4-a6d3-27661464c12c)

The screenshot shows a situation where the pageIndex in the URL is manuallly edited. This invalid (out of range) value is still reflected in the pagination component to give the user some more transparency