### PR TITLE
#2490 A direct link to latest run validation workflow on subscription General tab

### DIFF
--- a/.changeset/stale-ears-attack.md
+++ b/.changeset/stale-ears-attack.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+Add direct link to latest validate workflow in SubscriptionDetail (#2490)

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 
 import {
   PATH_TASKS,
-  PATH_WORKFLOWS,
   SubscriptionKeyValueBlock,
   WfoCustomerDescriptionsField,
   WfoInSyncField,

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 
 import {
+  PATH_TASKS,
+  PATH_WORKFLOWS,
   SubscriptionKeyValueBlock,
   WfoCustomerDescriptionsField,
   WfoInSyncField,
   WfoSubscriptionDetailNoteEdit,
   WfoSubscriptionStatusBadge,
 } from '@/components';
-import { SubscriptionDetail } from '@/types';
+import { SubscriptionDetail, WorkflowTarget } from '@/types';
 import { formatDate } from '@/utils';
 
 interface WfoSubscriptionDetailSectionProps {
@@ -19,8 +22,17 @@ interface WfoSubscriptionDetailSectionProps {
 export const WfoSubscriptionDetailSection = ({ subscriptionDetail }: WfoSubscriptionDetailSectionProps) => {
   const t = useTranslations('subscriptions.detail');
 
-  const { subscriptionId, product, description, startDate, endDate, status, customer, customerDescriptions } =
-    subscriptionDetail;
+  const {
+    subscriptionId,
+    product,
+    description,
+    startDate,
+    endDate,
+    status,
+    customer,
+    customerDescriptions,
+    processes,
+  } = subscriptionDetail;
 
   const subscriptionDetailBlockData = [
     {
@@ -51,6 +63,26 @@ export const WfoSubscriptionDetailSection = ({ subscriptionDetail }: WfoSubscrip
     {
       key: t('insync'),
       value: <WfoInSyncField subscriptionDetail={subscriptionDetail} />,
+    },
+    {
+      key: t('lastRunValidation'),
+      value: (() => {
+        const lastValidate = processes?.page
+          ?.filter((p) => p.workflowTarget.toLowerCase() === WorkflowTarget.VALIDATE.toLowerCase())
+          .slice(-1)[0];
+
+        if (!lastValidate) {
+          return t('noValidateWorkflows');
+        }
+
+        const processUrl = `${lastValidate.isTask ? PATH_TASKS : PATH_WORKFLOWS}/${lastValidate.processId}`;
+
+        return (
+          <Link href={processUrl}>
+            {lastValidate.lastStatus} ({formatDate(lastValidate.startedAt)})
+          </Link>
+        );
+      })(),
     },
     {
       key: t('customer'),

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
@@ -67,7 +67,7 @@ export const WfoSubscriptionDetailSection = ({ subscriptionDetail }: WfoSubscrip
       key: t('lastRunValidation'),
       value: (() => {
         const lastValidate = processes?.page
-          ?.filter((p) => p.workflowTarget.toLowerCase() === WorkflowTarget.VALIDATE.toLowerCase())
+          ?.filter((process) => process.workflowTarget.toLowerCase() === WorkflowTarget.VALIDATE.toLowerCase())
           .slice(-1)[0];
 
         if (!lastValidate) {

--- a/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoSubscription/WfoSubscriptionGeneralSections/WfoSubscriptionDetailSection.tsx
@@ -75,7 +75,7 @@ export const WfoSubscriptionDetailSection = ({ subscriptionDetail }: WfoSubscrip
           return t('noValidateWorkflows');
         }
 
-        const processUrl = `${lastValidate.isTask ? PATH_TASKS : PATH_WORKFLOWS}/${lastValidate.processId}`;
+        const processUrl = `${PATH_TASKS}/${lastValidate.processId}`;
 
         return (
           <Link href={processUrl}>

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -390,7 +390,7 @@
       "subscriptionId": "Subscription ID",
       "description": "Description",
       "startDate": "Start date",
-      "lastRunValidation": "Most Recent Validation Workflow",
+      "lastRunValidation": "Most recent validate",
       "noValidateWorkflows": "No validate workflows have been run recently",
       "insync": "In sync",
       "customer": "Customer",

--- a/packages/orchestrator-ui-components/src/messages/en-GB.json
+++ b/packages/orchestrator-ui-components/src/messages/en-GB.json
@@ -390,6 +390,8 @@
       "subscriptionId": "Subscription ID",
       "description": "Description",
       "startDate": "Start date",
+      "lastRunValidation": "Most Recent Validation Workflow",
+      "noValidateWorkflows": "No validate workflows have been run recently",
       "insync": "In sync",
       "customer": "Customer",
       "customerUuid": "Customer UUID",

--- a/packages/orchestrator-ui-components/src/messages/nl-NL.json
+++ b/packages/orchestrator-ui-components/src/messages/nl-NL.json
@@ -389,6 +389,8 @@
       "subscriptionId": "Subscription ID",
       "description": "Beschrijving",
       "startDate": "Startdatum",
+      "lastRunValidation": "Meest recente validate",
+      "noValidateWorkflows": "Er zijn recentelijk geen validate workflows uitgevoerd",
       "insync": "In sync",
       "customer": "Klant",
       "customerUuid": "Klant UUID",


### PR DESCRIPTION
This adds a section to the "General" tab in the subscription detail page.

<img width="656" height="797" alt="Screenshot 2026-04-14 at 09 08 58" src="https://github.com/user-attachments/assets/7a4e7486-8f3b-4fd1-959e-d17f38b80cf0" />

<img width="536" height="74" alt="Screenshot 2026-04-14 at 09 09 13" src="https://github.com/user-attachments/assets/40c37258-f2fd-498d-8baf-e799c3d6d14b" />

<img width="609" height="76" alt="Screenshot 2026-04-14 at 09 15 43" src="https://github.com/user-attachments/assets/e21c4f84-c920-4bb4-a359-7a3d66859c0f" />


Closes #2490