### PR TITLE
Add gh-pages.yml workflow + Adapt mkdocs.yml site_name

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,25 @@
+name: Dispatch to workfloworchestrator.github.io
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: workfloworchestrator
+          repositories: workfloworchestrator.github.io
+
+      - name: Trigger docs build on workfloworchestrator.github.io
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/workfloworchestrator/workfloworchestrator.github.io/dispatches \
+            -f event_type=docs-update

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -1,4 +1,5 @@
-site_name: Orchestrator UI docs
+# workfloworchestrator.github.io uses site_name in the URL, don't change it
+site_name: Orchestrator UI Library
 site_description: Orchestrator UI developers documentation
 repo_url: 'https://github.com/workfloworchestrator/orchestrator-ui'
 repo_name: 'orchestrator-ui'


### PR DESCRIPTION
This will ensure that after https://github.com/workfloworchestrator/workfloworchestrator.github.io/issues/21 the URL path of the /orchestrator-core/ documentation will not change.