### PR TITLE
WAITING FOR BACKEND RELEASE: Make the product state editable

### DIFF
--- a/.changeset/tame-ties-melt.md
+++ b/.changeset/tame-ties-melt.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': minor
+---
+
+Makes product metadata status and descriptio editable

--- a/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductStatusBadge/WfoProductStatusBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoBadges/WfoProductStatusBadge/WfoProductStatusBadge.tsx
@@ -8,13 +8,16 @@ export type WfoProductStatusBadgeProps = {
   status: ProductLifecycleStatus;
 };
 
+const normalizedStatus = (status: ProductLifecycleStatus): string => status.toLowerCase().replace(/_/g, ' ');
+
 export const WfoProductStatusBadge: FC<WfoProductStatusBadgeProps> = ({ status }) => {
   const { theme, toSecondaryColor } = useOrchestratorTheme();
 
-  const getBadgeColorFromStatus = (status: string) => {
+  const productLifeCycleStatus = normalizedStatus(status);
+  const getBadgeColorFromStatus = () => {
     const { primary, borderBaseSubdued, textPrimary, textParagraph, success, textSuccess } = theme.colors;
 
-    switch (status.toLowerCase()) {
+    switch (productLifeCycleStatus) {
       case ProductLifecycleStatus.ACTIVE:
         return {
           badgeColor: toSecondaryColor(success),
@@ -34,11 +37,11 @@ export const WfoProductStatusBadge: FC<WfoProductStatusBadgeProps> = ({ status }
     }
   };
 
-  const { badgeColor, textColor } = getBadgeColorFromStatus(status);
+  const { badgeColor, textColor } = getBadgeColorFromStatus();
 
   return (
     <WfoBadge textColor={textColor} color={badgeColor}>
-      {status.toLowerCase()}
+      {productLifeCycleStatus}
     </WfoBadge>
   );
 };

--- a/packages/orchestrator-ui-components/src/components/WfoMetadata/WfoMetadataStatusField.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoMetadata/WfoMetadataStatusField.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useState } from 'react';
+
+import { EuiButtonEmpty } from '@elastic/eui';
+
+import { ProductLifecycleStatus } from '@/types';
+
+import { WfoProductStatusBadge } from '../WfoBadges';
+import { WfoPopover } from '../WfoPopover';
+
+interface WfoMetadataStatusFieldProps {
+  onSave: (updatedStatus: ProductLifecycleStatus) => void;
+  currentStatus: ProductLifecycleStatus;
+}
+
+export const WfoMetadataStatusField: FC<WfoMetadataStatusFieldProps> = ({ onSave, currentStatus }) => {
+  const [isPopoverOpen, setPopover] = useState<boolean>(false);
+  const onButtonClick = () => setPopover(!isPopoverOpen);
+  const button = (
+    <EuiButtonEmpty iconType="arrowDown" iconSide="right" onClick={onButtonClick} color={'text'}>
+      <WfoProductStatusBadge status={currentStatus} />
+    </EuiButtonEmpty>
+  );
+
+  const handleOnSelectOption = (updatedStatus: ProductLifecycleStatus) => {
+    setPopover(false);
+    onSave(updatedStatus);
+  };
+
+  const setNewStatusBadges = () =>
+    Object.values(ProductLifecycleStatus).map((productStatus) => (
+      <EuiButtonEmpty onClick={() => handleOnSelectOption(productStatus)}>
+        <WfoProductStatusBadge status={productStatus} />
+      </EuiButtonEmpty>
+    ));
+
+  return (
+    <WfoPopover
+      id={'productStatusPopover'}
+      isLoading={false}
+      button={button}
+      isPopoverOpen={isPopoverOpen}
+      closePopover={() => setPopover(false)}
+      PopoverContent={setNewStatusBadges}
+    />
+  );
+};
+
+export default WfoMetadataStatusField;

--- a/packages/orchestrator-ui-components/src/components/WfoMetadata/index.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoMetadata/index.ts
@@ -1,0 +1,2 @@
+export * from './WfoMetadataDescriptionField';
+export * from './WfoMetadataStatusField';

--- a/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/metadata/WfoProductsPage.tsx
@@ -15,10 +15,10 @@ import {
   StoredTableConfig,
   WfoDateTime,
   WfoProductBlockBadge,
-  WfoProductStatusBadge,
   getDataSortHandler,
   getQueryStringHandler,
 } from '@/components';
+import { WfoMetadataStatusField } from '@/components/WfoMetadata';
 import { WfoMetadataDescriptionField } from '@/components/WfoMetadata/WfoMetadataDescriptionField';
 import { WfoAdvancedTable } from '@/components/WfoTable/WfoAdvancedTable';
 import { WfoAdvancedTableColumnConfig } from '@/components/WfoTable/WfoAdvancedTable/types';
@@ -26,10 +26,15 @@ import { WfoFirstPartUUID } from '@/components/WfoTable/WfoFirstPartUUID';
 import { ColumnType, Pagination } from '@/components/WfoTable/WfoTable';
 import { mapSortableAndFilterableValuesToTableColumnConfig } from '@/components/WfoTable/WfoTable/utils';
 import { useDataDisplayParams, useShowToastMessage, useStoredTableConfig } from '@/hooks';
-import { useGetProductsQuery, useLazyGetProductsQuery, useUpdateProductMutation } from '@/rtk';
+import {
+  useGetProductsQuery,
+  useLazyGetProductsQuery,
+  useUpdateProductDescriptionMutation,
+  useUpdateProductStatusMutation,
+} from '@/rtk';
 import { ProductsResponse } from '@/rtk';
 import { mapRtkErrorToWfoError } from '@/rtk/utils';
-import type { GraphqlQueryVariables, ProductDefinition } from '@/types';
+import type { GraphqlQueryVariables, ProductDefinition, ProductLifecycleStatus } from '@/types';
 import { BadgeType, SortOrder } from '@/types';
 import {
   getConcatenatedResult,
@@ -56,7 +61,8 @@ export const WfoProductsPage = () => {
   const [tableDefaults, setTableDefaults] = useState<StoredTableConfig<ProductDefinition>>();
 
   const getStoredTableConfig = useStoredTableConfig<ProductDefinition>(METADATA_PRODUCT_TABLE_LOCAL_STORAGE_KEY);
-  const [updateProduct] = useUpdateProductMutation();
+  const [updateProductDescription] = useUpdateProductDescriptionMutation();
+  const [updateProductStatus] = useUpdateProductStatusMutation();
 
   useEffect(() => {
     const storedConfig = getStoredTableConfig();
@@ -106,7 +112,7 @@ export const WfoProductsPage = () => {
       renderData: (value, row) => (
         <WfoMetadataDescriptionField
           onSave={(updatedNote) =>
-            updateProduct({
+            updateProductDescription({
               id: row.productId,
               description: updatedNote,
             })
@@ -123,8 +129,18 @@ export const WfoProductsPage = () => {
     status: {
       columnType: ColumnType.DATA,
       label: t('status'),
-      width: '90px',
-      renderData: (value) => <WfoProductStatusBadge status={value} />,
+      width: '150px',
+      renderData: (value, row) => (
+        <WfoMetadataStatusField
+          onSave={(updatedStatus: ProductLifecycleStatus) =>
+            updateProductStatus({
+              id: row.productId,
+              status: updatedStatus,
+            })
+          }
+          currentStatus={value}
+        />
+      ),
     },
     fixedInputs: {
       columnType: ColumnType.DATA,

--- a/packages/orchestrator-ui-components/src/rtk/api.ts
+++ b/packages/orchestrator-ui-components/src/rtk/api.ts
@@ -165,6 +165,7 @@ export const orchestratorApi = createApi({
     CacheTagType.processStatusCounts,
     CacheTagType.subscriptions,
     CacheTagType.scheduledTasks,
+    CacheTagType.metadataProducts,
   ],
   keepUnusedDataFor: process.env.NEXT_PUBLIC_DISABLE_CACHE === 'true' ? 0 : 60 * 60 * 1000,
 });

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/metadata/products.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/metadata/products.ts
@@ -2,12 +2,14 @@ import { METADATA_PRODUCT_ENDPOINT } from '@/configuration/constants';
 import { BaseQueryTypes, orchestratorApi } from '@/rtk';
 import {
   BaseGraphQlResult,
+  CacheTagType,
   GraphqlQueryVariables,
   MetadataDescriptionParams,
   MetadataStatusParams,
   ProductDefinition,
   ProductDefinitionsResult,
 } from '@/types';
+import { getCacheTag } from '@/utils';
 
 export const products = `
     query MetadataProducts(
@@ -67,6 +69,7 @@ const productsApi = orchestratorApi.injectEndpoints({
           pageInfo,
         };
       },
+      providesTags: getCacheTag(CacheTagType.metadataProducts),
     }),
   }),
 });
@@ -89,6 +92,7 @@ const productRestApi = orchestratorApi.injectEndpoints({
       extraOptions: {
         baseQueryType: BaseQueryTypes.fetch,
       },
+      invalidatesTags: getCacheTag(CacheTagType.metadataProducts),
     }),
     updateProductStatus: build.mutation<null, MetadataStatusParams>({
       query: (product) => ({
@@ -104,6 +108,7 @@ const productRestApi = orchestratorApi.injectEndpoints({
       extraOptions: {
         baseQueryType: BaseQueryTypes.fetch,
       },
+      invalidatesTags: getCacheTag(CacheTagType.metadataProducts),
     }),
   }),
 });

--- a/packages/orchestrator-ui-components/src/rtk/endpoints/metadata/products.ts
+++ b/packages/orchestrator-ui-components/src/rtk/endpoints/metadata/products.ts
@@ -4,6 +4,7 @@ import {
   BaseGraphQlResult,
   GraphqlQueryVariables,
   MetadataDescriptionParams,
+  MetadataStatusParams,
   ProductDefinition,
   ProductDefinitionsResult,
 } from '@/types';
@@ -74,7 +75,7 @@ export const { useGetProductsQuery, useLazyGetProductsQuery } = productsApi;
 
 const productRestApi = orchestratorApi.injectEndpoints({
   endpoints: (build) => ({
-    updateProduct: build.mutation<null, MetadataDescriptionParams>({
+    updateProductDescription: build.mutation<null, MetadataDescriptionParams>({
       query: (product) => ({
         url: `${METADATA_PRODUCT_ENDPOINT}/${product.id}`,
         method: 'PATCH',
@@ -89,7 +90,22 @@ const productRestApi = orchestratorApi.injectEndpoints({
         baseQueryType: BaseQueryTypes.fetch,
       },
     }),
+    updateProductStatus: build.mutation<null, MetadataStatusParams>({
+      query: (product) => ({
+        url: `${METADATA_PRODUCT_ENDPOINT}/${product.id}`,
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: {
+          status: product.status,
+        },
+      }),
+      extraOptions: {
+        baseQueryType: BaseQueryTypes.fetch,
+      },
+    }),
   }),
 });
 
-export const { useUpdateProductMutation } = productRestApi;
+export const { useUpdateProductDescriptionMutation, useUpdateProductStatusMutation } = productRestApi;

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -508,10 +508,10 @@ export type ProcessPatchParams = {
   note: string | null;
 };
 
-// export type Workflow = {
-//     workflow_id: string;
-//     description: string;
-// };
+export type MetadataStatusParams = {
+  id: string;
+  status: ProductLifecycleStatus;
+};
 
 export type SubscriptionDetail = {
   subscriptionId: string;

--- a/packages/orchestrator-ui-components/src/types/types.ts
+++ b/packages/orchestrator-ui-components/src/types/types.ts
@@ -629,6 +629,7 @@ export enum CacheTagType {
   processStatusCounts = 'processStatusCounts',
   subscriptions = 'subscriptions',
   scheduledTasks = 'scheduledTags',
+  metadataProducts = 'metadataProducts',
 }
 
 export interface MappedVersion {

--- a/version-compatibility.json
+++ b/version-compatibility.json
@@ -1,13 +1,13 @@
 [
   {
+    "orchestratorUiVersion": "7.8.0",
+    "minimumOrchestratorCoreVersion": "5.0.0",
+    "changes": "Endpoints in BE to modify the lifecycle status of a product."
+  },
+  {
     "orchestratorUiVersion": "7.7.0",
     "minimumOrchestratorCoreVersion": "5.0.0",
     "changes": "A note field was added to a process"
-  },
-  {
-    "orchestratorUiVersion": "7.8.0",
-    "minimumOrchestratorCoreVersion": "5.0.0",
-    "changes": "Endpointsin BE to modify the lifecycle status of a product."
   },
   {
     "orchestratorUiVersion": "6.5.0",

--- a/version-compatibility.json
+++ b/version-compatibility.json
@@ -5,6 +5,11 @@
     "changes": "A note field was added to a process"
   },
   {
+    "orchestratorUiVersion": "7.8.0",
+    "minimumOrchestratorCoreVersion": "5.0.0",
+    "changes": "Endpointsin BE to modify the lifecycle status of a product."
+  },
+  {
     "orchestratorUiVersion": "6.5.0",
     "minimumOrchestratorCoreVersion": "4.6.0",
     "changes": "To support new functionality in the FE for the Agent and LLM, the BE endpoints have changed."

--- a/version-compatibility.json
+++ b/version-compatibility.json
@@ -1,12 +1,12 @@
 [
   {
     "orchestratorUiVersion": "7.8.0",
-    "minimumOrchestratorCoreVersion": "5.0.0",
+    "minimumOrchestratorCoreVersion": "5.0.0rc1",
     "changes": "Endpoints in BE to modify the lifecycle status of a product."
   },
   {
     "orchestratorUiVersion": "7.7.0",
-    "minimumOrchestratorCoreVersion": "5.0.0",
+    "minimumOrchestratorCoreVersion": "5.0.0rc1",
     "changes": "A note field was added to a process"
   },
   {


### PR DESCRIPTION
This PR will allow the user to update the status of a product from the products metadata page.
The only thing I haven't been able to get to work is how to refresh the table once a button is clicked. A manual refresh updates the state, but I don't like that UX.

Closes #2239 

<img width="1103" height="229" alt="image" src="https://github.com/user-attachments/assets/c716c3e2-862d-4e99-813f-c378c74bcffa" />
