### PR TITLE
Add react node to WfoTitleWithWebsocketBadge

### DIFF
--- a/.changeset/frank-days-rush.md
+++ b/.changeset/frank-days-rush.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': minor
+---
+
+140 Add react node to WfoTitleWithWebsocketBadge

--- a/packages/orchestrator-ui-components/src/components/WfoTitleWithWebsocketBadge/WfoTitleWithWebsocketBadge.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTitleWithWebsocketBadge/WfoTitleWithWebsocketBadge.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-import { EuiPageHeader } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPageHeader } from '@elastic/eui';
 
 import { WfoWebsocketStatusBadge } from '@/components';
 import { useGetOrchestratorConfig } from '@/hooks';
 
 interface WfoTitleWithWebsocketBadgeProps {
-  title: string;
+  title: string | ReactNode;
   wsUrl?: string;
 }
 
@@ -15,9 +15,12 @@ export const WfoTitleWithWebsocketBadge = ({ title, wsUrl = undefined }: WfoTitl
 
   const pageTitle =
     useWebSockets ?
-      <>
-        {title} <WfoWebsocketStatusBadge wsUrl={wsUrl} />
-      </>
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>{title}</EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <WfoWebsocketStatusBadge wsUrl={wsUrl} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     : title;
 
   return <EuiPageHeader pageTitle={pageTitle} />;


### PR DESCRIPTION
In the Chassis detail page of SURF the title is not only a string, but also contains html elements. This doesn't affect the current styling of the titles of the already existing pages.

<img width="880" height="190" alt="Screenshot 2026-05-20 at 15 05 11" src="https://github.com/user-attachments/assets/2775c34b-0534-42ad-9429-f237e3261c90" />
