### PR TITLE
feat(tasks): add notes column to task list page

### DIFF
--- a/.changeset/itchy-cobras-play.md
+++ b/.changeset/itchy-cobras-play.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+add notes column to task list page

--- a/packages/orchestrator-ui-components/src/pages/tasks/WfoTasksListPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/tasks/WfoTasksListPage.tsx
@@ -110,6 +110,7 @@ export const WfoTasksListPage = () => {
       'productName',
       'customer',
       'customerAbbreviation',
+      'note',
       'subscriptions',
       'createdBy',
       'assignee',


### PR DESCRIPTION
Add the note column to the task list page with inline edit functionality, similar to the workflow list page. This allows users to edit process notes directly from the task list view.