### PR TITLE
Fix typo in README: wfo-iu -> wfo-ui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "apps/wfo-ui"]
 	path = apps/wfo-ui
-	url = git@github.com:workfloworchestrator/example-orchestrator-ui.git
+	url = https://github.com/workfloworchestrator/example-orchestrator-ui.git

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git submodule init
 git submodule update
 # Optionally: to update to the latest version of the git submodule instead of the ones currently pinned to the repo run
 git submodule update --remote
-cp apps/wfo-ui/.env.example apps/wfo-iu/.env
+cp apps/wfo-ui/.env.example apps/wfo-ui/.env
 # change the values in the env file to point to your orchestrator backend
 # set auth=false or follow the directions below this sections
 npm install

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ git submodule update --remote
 cp apps/wfo-ui/.env.example apps/wfo-ui/.env
 # change the values in the env file to point to your orchestrator backend
 # set OAUTH2_ACTIVE=false or follow the directions below this sections
-npm install
+npm install # also builds the shared packages via a postinstall hook, can take a few minutes on first run
 npm run dev
 ```
 
-This makes the orchestrator ui run on http://localhost:3000
+This makes the orchestrator ui run on http://localhost:3000, unless that port is already in use, in which case Next.js picks the next available port and prints the actual URL to the terminal.
 
 ## Websocket
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is meant to be used together with an app that includes this library through N
 To install and run the app:
 
 ```
-git clone git@github.com:workfloworchestrator/orchestrator-ui-library.git
+git clone https://github.com/workfloworchestrator/orchestrator-ui-library.git
 cd orchestrator-ui-library
 git submodule init
 git submodule update
@@ -14,7 +14,7 @@ git submodule update
 git submodule update --remote
 cp apps/wfo-ui/.env.example apps/wfo-ui/.env
 # change the values in the env file to point to your orchestrator backend
-# set auth=false or follow the directions below this sections
+# set OAUTH2_ACTIVE=false or follow the directions below this sections
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- Fixes a typo in the setup instructions where the target `.env` path was `apps/wfo-iu/.env` instead of `apps/wfo-ui/.env`.

## Test plan
- N/A, docs-only change.