### PR TITLE
222 query string

### DIFF
--- a/.changeset/cute-ads-lie.md
+++ b/.changeset/cute-ads-lie.md
@@ -1,0 +1,5 @@
+---
+'@orchestrator-ui/orchestrator-ui-components': patch
+---
+
+Fix query and filter not being applied in certain cases

--- a/package-lock.json
+++ b/package-lock.json
@@ -752,7 +752,7 @@
       }
     },
     "apps/wfo-ui-surf": {
-      "version": "6.11.0",
+      "version": "6.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
@@ -20425,7 +20425,7 @@
     },
     "packages/orchestrator-ui-components": {
       "name": "@orchestrator-ui/orchestrator-ui-components",
-      "version": "8.8.1",
+      "version": "8.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoSearchFieldWithActions.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoSearchFieldWithActions.tsx
@@ -8,18 +8,18 @@ import { useWithOrchestratorTheme } from '@/hooks';
 import { getFormFieldsBaseStyle } from '@/theme';
 
 export type SearchFieldWithActionsProps = {
-  queryText?: string;
-  onChangeQueryText: (queryText: string) => void;
-  onSearchQueryText: (queryText: string) => void;
+  queryString?: string;
+  onChangeQueryString: (queryText: string) => void;
+  onSearchQueryString: (queryText: string) => void;
   onShowInformation: () => void;
   onShowTableSettings: () => void;
 };
 
 // Search field with the info and table-settings actions, rendered as EuiFlexItems inside an EuiFlexGroup.
 export const WfoSearchFieldWithActions = ({
-  queryText,
-  onChangeQueryText,
-  onSearchQueryText,
+  queryString,
+  onChangeQueryString,
+  onSearchQueryString,
   onShowInformation,
   onShowTableSettings,
 }: SearchFieldWithActionsProps) => {
@@ -32,10 +32,10 @@ export const WfoSearchFieldWithActions = ({
         <EuiFormRow fullWidth>
           <EuiFieldSearch
             css={formFieldBaseStyle}
-            value={queryText}
+            value={queryString}
             placeholder={`${t('search')}...`}
-            onChange={(e) => onChangeQueryText(e.target.value)}
-            onSearch={(queryText) => onSearchQueryText(queryText)}
+            onChange={(e) => onChangeQueryString(e.target.value)}
+            onSearch={(queryText) => onSearchQueryString(queryText)}
             fullWidth
           />
         </EuiFormRow>

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoSearchFieldWithActions.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoSearchFieldWithActions.tsx
@@ -9,8 +9,8 @@ import { getFormFieldsBaseStyle } from '@/theme';
 
 export type SearchFieldWithActionsProps = {
   queryString?: string;
-  onChangeQueryString: (queryText: string) => void;
-  onSearchQueryString: (queryText: string) => void;
+  onChangeQueryString: (queryString: string) => void;
+  onSearchQueryString: (queryString: string) => void;
   onShowInformation: () => void;
   onShowTableSettings: () => void;
 };
@@ -35,7 +35,7 @@ export const WfoSearchFieldWithActions = ({
             value={queryString}
             placeholder={`${t('search')}...`}
             onChange={(e) => onChangeQueryString(e.target.value)}
-            onSearch={(queryText) => onSearchQueryString(queryText)}
+            onSearch={(queryString) => onSearchQueryString(queryString)}
             fullWidth
           />
         </EuiFormRow>

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoStructuredSearchTable.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoStructuredSearchTable.tsx
@@ -54,7 +54,7 @@ export type WfoStructuredSearchTableColumnConfig<T extends object> = Partial<
   WfoTableControlColumnConfig<T> | WfoStructuredSearchTableDataColumnConfig<T>
 >;
 export type SearchParams = {
-  queryText?: string | false;
+  queryString?: string | false;
   retrieverType?: RetrieverType;
   ruleGroup?: RuleGroupType | false;
   limit?: number;
@@ -73,12 +73,12 @@ export type WfoStructuredSearchTableProps<T extends object> = Omit<
   defaultHiddenColumns?: TableColumnKeys<T>;
   defaultShowMatchDetails?: boolean;
   defaultAdvancedNestedSearch?: boolean;
-  queryText?: string;
+  queryString?: string;
   localStorageKey: string;
   exportDataIsLoading?: boolean;
   error?: WfoGraphqlError[];
-  onChangeQueryText: (queryString: string) => void;
-  onSearchQueryText: (queryString: string) => void;
+  onChangeQueryString: (queryString: string) => void;
+  onSearchQueryString: (queryString: string) => void;
   onShowMore: () => void;
   onUpdateDataSorting: (updateSorting: WfoDataSorting<T>) => void;
   // Resolves a column key to its search field path (e.g. "status" -> "subscription.status"), used
@@ -105,12 +105,12 @@ export const WfoStructuredSearchTable = <T extends object>({
   defaultHiddenColumns = [],
   defaultShowMatchDetails = false,
   defaultAdvancedNestedSearch = true,
-  queryText,
+  queryString,
   localStorageKey,
   exportDataIsLoading,
   error,
-  onChangeQueryText,
-  onSearchQueryText,
+  onChangeQueryString,
+  onSearchQueryString,
   onShowMore,
   onExportData,
   retrieverType,
@@ -264,9 +264,9 @@ export const WfoStructuredSearchTable = <T extends object>({
           </EuiFlexItem>
         )}
         <WfoSearchFieldWithActions
-          queryText={queryText}
-          onChangeQueryText={onChangeQueryText}
-          onSearchQueryText={onSearchQueryText}
+          queryString={queryString}
+          onChangeQueryString={onChangeQueryString}
+          onSearchQueryString={onSearchQueryString}
           onShowInformation={() => setShowInformationModal(true)}
           onShowTableSettings={() => setShowTableSettingsModal(true)}
         />

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -344,23 +344,30 @@ export const WfoSearchPocPage = () => {
       sortableAndFilterableFieldNames,
     );
 
+  // Formats the given rule group to CEL and commits it. Returns false without committing when
+  // the CEL would not survive the URL round trip: formatQuery escapes double quotes in values
+  // but parseCEL has no escape support, so such a filter would silently be dropped after
+  // committing. Refusing keeps the URL and the search results consistent.
+  const commitFilterDraft = (effectiveRuleGroup: RuleGroupType | undefined): boolean => {
+    // '' (no rule group, or only placeholder rules) commits an empty filter, clearing the URL param.
+    const celQuery =
+      effectiveRuleGroup ? formatQuery(effectiveRuleGroup, { format: 'cel', fallbackExpression: '' }) : '';
+    if (celQuery && !parseCelToRuleGroup(celQuery)) {
+      setIsValidFilterString(false);
+      return false;
+    }
+    commitFilterString(celQuery);
+    return true;
+  };
+
   const handleApplyFilter = (searchParams?: SearchParams) => {
     const ruleGroupParam = searchParams?.ruleGroup;
     // Use an explicitly passed rule group when provided (e.g. a column-header search), a cleared filter
     // when `false`, and otherwise the current query builder state (the "Apply filter" button).
     const effectiveRuleGroup = ruleGroupParam === false ? undefined : (ruleGroupParam ?? queryBuilderRuleGroup);
-    // '' (no rule group, or only placeholder rules) commits an empty filter, clearing the URL param.
-    const celQuery =
-      effectiveRuleGroup ? formatQuery(effectiveRuleGroup, { format: 'cel', fallbackExpression: '' }) : '';
-    // A non-empty CEL string must survive the round trip through the URL: formatQuery escapes double
-    // quotes in values but parseCEL has no escape support, so such a filter would silently be dropped
-    // after committing. Refuse the commit and flag the filter instead, keeping the URL and the search
-    // results consistent.
-    if (celQuery && !parseCelToRuleGroup(celQuery)) {
-      setIsValidFilterString(false);
+    if (!commitFilterDraft(effectiveRuleGroup)) {
       return;
     }
-    commitFilterString(celQuery);
     // Also commit the draft search text, so applying a filter picks up text typed in the
     // search bar without pressing enter.
     commitQueryString(queryString);
@@ -374,6 +381,12 @@ export const WfoSearchPocPage = () => {
   const onSearchQueryString = (queryString: string) => {
     setQueryString(queryString);
     commitQueryString(queryString);
+    // Mirror handleApplyFilter: searching also commits a pending filter draft. An invalid draft
+    // (already flagged at the textarea) is skipped instead of blocking the search — the query
+    // commits and the committed filter stays as it was.
+    if (isValidFilterString) {
+      commitFilterDraft(queryBuilderRuleGroup);
+    }
     setPageCursor(undefined);
   };
 

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -149,11 +149,12 @@ export const WfoSearchPocPage = () => {
   const getStoredTableConfig = useStoredTableConfig<SubscriptionListItem>(SEARCH_TABLE_LOCAL_STORAGE_KEY);
   const [retrieverType, setRetrieverType] = useState<RetrieverType>(RetrieverType.Auto);
 
-  // Part of the search endpoint payload that is passed in the q parameter
-  const [queryText, setQueryText] = useState<string>('');
+  // Part of the search endpoint payload that is passed in the queryString parameter
+  const [queryString, setQueryString] = useState<string>('');
+
   // The committed query and filter live in the URL so a link reproduces the search and browser
   // back/forward re-runs it. The filter is stored as a CEL string and parsed back to a rule group.
-  const [committedSearchQuery, setCommittedSearchQuery] = useQueryParam('queryString', withDefault(StringParam, ''));
+  const [committedQueryString, setCommittedQueryString] = useQueryParam('queryString', withDefault(StringParam, ''));
   const [committedFilterString, setCommittedFilterString] = useQueryParam('filterString', withDefault(StringParam, ''));
   // Track the last value this page committed, so the URL->state sync effects below only rebuild the
   // inputs for external changes (page load, back/forward). Rebuilding on own commits would revert
@@ -165,10 +166,10 @@ export const WfoSearchPocPage = () => {
     lastSelfCommittedFilter.current = celString;
     setCommittedFilterString(celString || undefined);
   };
-  const lastSelfCommittedQuery = useRef('');
-  const commitSearchQuery = (queryText: string) => {
-    lastSelfCommittedQuery.current = queryText;
-    setCommittedSearchQuery(queryText || undefined);
+  const lastSelfCommittedQueryString = useRef('');
+  const commitQueryString = (queryString: string) => {
+    lastSelfCommittedQueryString.current = queryString;
+    setCommittedQueryString(queryString || undefined);
   };
 
   // String that is displayed in the filter textarea. This is transformed and if valid passed to the search endpoint in the filter parameter
@@ -192,7 +193,7 @@ export const WfoSearchPocPage = () => {
   // the queryString/filterString/activeTab URL params: the key no longer matches, so the stale
   // cursor is not sent along with the new search.
   const committedSearchKey = JSON.stringify([
-    committedSearchQuery,
+    committedQueryString,
     committedFilterString,
     selectedTab,
     retrieverType,
@@ -213,7 +214,7 @@ export const WfoSearchPocPage = () => {
       direction: dataSorting.sortOrder.toLowerCase(),
     };
     return {
-      query: committedSearchQuery,
+      query: committedQueryString,
       limit: pageSize,
       entity_type: EntityKind.SUBSCRIPTION,
       response_columns: Array.from(resultColumToPropertyMap.keys()),
@@ -222,7 +223,7 @@ export const WfoSearchPocPage = () => {
       ...(filters && { filters }),
       ...(cursor && { cursor }),
     };
-  }, [committedSearchQuery, committedRuleGroup, selectedTab, retrieverType, pageSize, dataSorting, cursor]);
+  }, [committedQueryString, committedRuleGroup, selectedTab, retrieverType, pageSize, dataSorting, cursor]);
 
   const { data, isFetching } = useSearchQuery(searchPayload);
 
@@ -335,7 +336,7 @@ export const WfoSearchPocPage = () => {
   };
 
   const sortableAndFilterableFieldNames = Object.keys(tableColumnConfig).filter((fieldName) => fieldName !== 'actions');
-  const isSortingAllowed = queryText === '';
+  const isSortingAllowed = queryString === '';
   const tableColumnConfigWithSortingAndFiltering =
     mapSortableAndFilterableValuesToTableColumnConfig<SubscriptionListItem>(
       tableColumnConfig,
@@ -363,13 +364,13 @@ export const WfoSearchPocPage = () => {
     setPageCursor(undefined);
   };
 
-  const onChangeQueryText = (queryText: string) => {
-    setQueryText(queryText);
+  const onChangeQueryText = (queryString: string) => {
+    setQueryString(queryString);
   };
 
-  const onSearchQueryText = (queryText: string) => {
-    setQueryText(queryText);
-    commitSearchQuery(queryText);
+  const onSearchQueryText = (queryString: string) => {
+    setQueryString(queryString);
+    commitQueryString(queryString);
     setPageCursor(undefined);
   };
 
@@ -405,12 +406,12 @@ export const WfoSearchPocPage = () => {
   // back/forward navigation changes the committed search. Commits made by this page are skipped —
   // see the lastSelfCommitted refs above.
   useEffect(() => {
-    if (committedSearchQuery === lastSelfCommittedQuery.current) {
+    if (committedQueryString === lastSelfCommittedQueryString.current) {
       return;
     }
-    lastSelfCommittedQuery.current = committedSearchQuery;
-    setQueryText(committedSearchQuery);
-  }, [committedSearchQuery]);
+    lastSelfCommittedQueryString.current = committedQueryString;
+    setQueryString(committedQueryString);
+  }, [committedQueryString]);
 
   useEffect(() => {
     if (committedFilterString === lastSelfCommittedFilter.current) {
@@ -526,7 +527,7 @@ export const WfoSearchPocPage = () => {
         onShowMore={onShowMore}
         onUpdateRetrieverType={onUpdateRetrieverType}
         queryBuilderRuleGroup={queryBuilderRuleGroup}
-        queryText={queryText}
+        queryText={queryString}
         retrieverType={retrieverType}
         tableColumnConfig={tableColumnConfigWithSortingAndFiltering}
         getColumnSearchFieldName={(field) => getKeyByValueFromMap(resultColumToPropertyMap, field)}

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -361,6 +361,9 @@ export const WfoSearchPocPage = () => {
       return;
     }
     commitFilterString(celQuery);
+    // Also commit the draft search text, so applying a filter picks up text typed in the
+    // search bar without pressing enter.
+    commitQueryString(queryString);
     setPageCursor(undefined);
   };
 

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -364,11 +364,11 @@ export const WfoSearchPocPage = () => {
     setPageCursor(undefined);
   };
 
-  const onChangeQueryText = (queryString: string) => {
+  const onChangeQueryString = (queryString: string) => {
     setQueryString(queryString);
   };
 
-  const onSearchQueryText = (queryString: string) => {
+  const onSearchQueryString = (queryString: string) => {
     setQueryString(queryString);
     commitQueryString(queryString);
     setPageCursor(undefined);
@@ -522,12 +522,12 @@ export const WfoSearchPocPage = () => {
         localStorageKey={SEARCH_TABLE_LOCAL_STORAGE_KEY}
         onUpdateFilterString={onUpdateFilterString}
         onUpdateQueryBuilder={onUpdateQueryBuilder}
-        onChangeQueryText={onChangeQueryText}
-        onSearchQueryText={onSearchQueryText}
+        onChangeQueryString={onChangeQueryString}
+        onSearchQueryString={onSearchQueryString}
         onShowMore={onShowMore}
         onUpdateRetrieverType={onUpdateRetrieverType}
         queryBuilderRuleGroup={queryBuilderRuleGroup}
-        queryText={queryString}
+        queryString={queryString}
         retrieverType={retrieverType}
         tableColumnConfig={tableColumnConfigWithSortingAndFiltering}
         getColumnSearchFieldName={(field) => getKeyByValueFromMap(resultColumToPropertyMap, field)}

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -180,6 +180,9 @@ export const WfoSearchPocPage = () => {
     [committedFilterString],
   );
   const [isValidFilterString, setIsValidFilterString] = useState<boolean>(true);
+  // Set when a commit attempt (Apply filter, or enter in the search bar) is refused because the
+  // filter draft is invalid; used to hide the search results — see isSearchBlocked below.
+  const [isCommitRefused, setIsCommitRefused] = useState<boolean>(false);
   const [tableDefaults, setTableDefaults] = useState<StoredTableConfig<SubscriptionListItem>>();
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [pageCursor, setPageCursor] = useState<{ cursor: string; searchKey: string } | undefined>(undefined);
@@ -354,9 +357,11 @@ export const WfoSearchPocPage = () => {
       effectiveRuleGroup ? formatQuery(effectiveRuleGroup, { format: 'cel', fallbackExpression: '' }) : '';
     if (celQuery && !parseCelToRuleGroup(celQuery)) {
       setIsValidFilterString(false);
+      setIsCommitRefused(true);
       return false;
     }
     commitFilterString(celQuery);
+    setIsCommitRefused(false);
     return true;
   };
 
@@ -380,13 +385,18 @@ export const WfoSearchPocPage = () => {
 
   const onSearchQueryString = (queryString: string) => {
     setQueryString(queryString);
-    commitQueryString(queryString);
-    // Mirror handleApplyFilter: searching also commits a pending filter draft. An invalid draft
-    // (already flagged at the textarea) is skipped instead of blocking the search — the query
-    // commits and the committed filter stays as it was.
-    if (isValidFilterString) {
-      commitFilterDraft(queryBuilderRuleGroup);
+    // Mirror handleApplyFilter: searching also commits the pending filter draft, and an invalid
+    // draft refuses the whole search — nothing commits and the results are hidden until the
+    // draft is fixed. The isValidFilterString check guards the textarea state, which the
+    // queryBuilderRuleGroup (holding the last *valid* parse) does not reflect while invalid.
+    if (!isValidFilterString) {
+      setIsCommitRefused(true);
+      return;
     }
+    if (!commitFilterDraft(queryBuilderRuleGroup)) {
+      return;
+    }
+    commitQueryString(queryString);
     setPageCursor(undefined);
   };
 
@@ -472,13 +482,18 @@ export const WfoSearchPocPage = () => {
     safeCelParse(filterString);
   };
 
+  // A refused commit hides the search results for as long as the filter draft stays invalid:
+  // showing them would suggest the attempted search ran. Editing the draft back to valid CEL
+  // (or a later successful commit) lifts the block.
+  const isSearchBlocked = isCommitRefused && !isValidFilterString;
+
   const { items: subscriptionListItems, rowExpandingConfiguration } =
-    data ?
+    data && !isSearchBlocked ?
       getDataFromResponse<SubscriptionListItem>(data, resultColumToPropertyMap, 'subscriptionId', selectedTab)
     : { items: [] };
 
-  const totalItems = getTotalItemsFromResponse(data);
-  const hasNextPage = data?.page_info?.has_next_page ?? false;
+  const totalItems = !isSearchBlocked && getTotalItemsFromResponse(data);
+  const hasNextPage = !isSearchBlocked && (data?.page_info?.has_next_page ?? false);
   const nextPageCursor = data?.page_info?.next_page_cursor ?? undefined;
 
   const exportData = async () => {


### PR DESCRIPTION
Fixes the situation where you change something in either the filterString or the queryString and don't submit it right away (by 'enter') but submit the search by commiting from the other input (so either the query input field or the filterBuilder). In that case what get's submitted to search ignored those first changes leading to mistmatches to results and the url. 