### PR TITLE
Enable 'does not contain' search filter

### DIFF
--- a/packages/orchestrator-ui-components/src/components/WfoSearchPage/utils.ts
+++ b/packages/orchestrator-ui-components/src/components/WfoSearchPage/utils.ts
@@ -94,6 +94,7 @@ const OPERATOR_MAP: Record<string, OperatorDisplay> = {
   has_component: { symbol: '✓', description: 'has component' },
   not_has_component: { symbol: '✗', description: 'does not have component' },
   like: { symbol: '∋', description: 'contains' },
+  not_regexp: { symbol: '∌', description: 'does not contain' },
 };
 
 const BOOLEAN_OPERATOR_MAP: Record<string, OperatorDisplay> = {

--- a/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoFilterBuilder.tsx
+++ b/packages/orchestrator-ui-components/src/components/WfoTable/WfoStructuredSearchTable/WfoFilterBuilder.tsx
@@ -42,6 +42,7 @@ const SEARCH_OPERATOR_TO_RQB_OPERATOR_MAP: Record<string, string> = {
   gte: '>=',
   between: 'between',
   like: 'contains',
+  not_regexp: 'doesNotContain',
   has_component: 'notNull',
   not_has_component: 'null',
 };
@@ -60,6 +61,7 @@ const OPERATOR_MAP: Record<string, OperatorDisplay> = {
   has_component: { symbol: '✓', description: 'has component' },
   not_has_component: { symbol: '✗', description: 'does not have component' },
   like: { symbol: '∋', description: 'contains' },
+  not_regexp: { symbol: '∌', description: 'does not contain' },
 };
 
 interface WfoFilterBuilderProps {

--- a/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
+++ b/packages/orchestrator-ui-components/src/pages/WfoSearchPocPage.tsx
@@ -129,17 +129,17 @@ const resultColumToPropertyMap: ResultColumToPropertyMap<SubscriptionListItem> =
 
 /* These options will be added as the first options in the field dropdown in the FieldSelector */
 const prefilledFieldOptions: FieldToOperatorMap = new Map([
-  ['subscription.subscription_id', ['eq', 'neq', 'like']],
-  ['subscription.description', ['eq', 'neq', 'like']],
-  ['subscription.status', ['eq', 'neq', 'like']],
+  ['subscription.subscription_id', ['eq', 'neq', 'like', 'not_regexp']],
+  ['subscription.description', ['eq', 'neq', 'like', 'not_regexp']],
+  ['subscription.status', ['eq', 'neq', 'like', 'not_regexp']],
   ['subscription.insync', ['eq', 'neq']],
-  ['subscription.product.name', ['eq', 'neq', 'like']],
-  ['subscription.product.tag', ['eq', 'neq', 'like']],
-  ['subscription.customer_name', ['eq', 'neq', 'like']],
-  ['subscription.customer_abbreviation', ['eq', 'neq', 'like']],
+  ['subscription.product.name', ['eq', 'neq', 'like', 'not_regexp']],
+  ['subscription.product.tag', ['eq', 'neq', 'like', 'not_regexp']],
+  ['subscription.customer_name', ['eq', 'neq', 'like', 'not_regexp']],
+  ['subscription.customer_abbreviation', ['eq', 'neq', 'like', 'not_regexp']],
   ['subscription.start_date', ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between']],
   ['subscription.end_date', ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between']],
-  ['subscription.note', ['eq', 'neq', 'like']],
+  ['subscription.note', ['eq', 'neq', 'like', 'not_regexp']],
 ]);
 
 export const WfoSearchPocPage = () => {


### PR DESCRIPTION
## Enable "does not contain" string operator in the search filter builder

The backend supports `not_regexp` for string fields, but the frontend had no
mapping for it, so "does not contain" never appeared in the operator dropdown.

### Changes

- `WfoFilterBuilder.tsx`: map `not_regexp` to react-querybuilder's
  `doesNotContain` and add its display entry (`∌ does not contain`).
- `WfoSearchPage/utils.ts`: add the same display entry.
- `WfoSearchPocPage.tsx`: add `not_regexp` to the prefilled operator lists of
  all string fields, so the operator stays available when a field is
  re-selected from the prefilled dropdown (it previously disappeared after
  deleting and re-adding a rule).

<img width="1897" height="934" alt="image" src="https://github.com/user-attachments/assets/dbe02611-d7f0-4ac8-b82e-a6f7bc279d8e" />

### How to test

1. Add a filter rule on a string field — "∌ does not contain" is listed.
2. Delete the rule and re-add it — the operator is still listed.
3. Apply the filter and verify matching subscriptions are excluded.

### Related issues
Fixes https://git.ia.surf.nl/netdev/automation/projects/orchestrator/-/work_items/2896
orchestrator-core https://github.com/workfloworchestrator/orchestrator-core/pull/1868